### PR TITLE
Unify Lista Corte revision creation

### DIFF
--- a/funciones.php
+++ b/funciones.php
@@ -606,3 +606,88 @@ if (!function_exists('str_starts_with')) {
     return $needle !== '' && strpos($haystack, $needle) === 0;
   }
 }
+
+/**
+ * Inserta una revisión de lista de corte y devuelve su ID.
+ */
+function crearListaCorteRevision(PDO $pdo, array $datos): int {
+  $sql = "INSERT INTO listas_corte_revisiones (id_lista_corte, id_proyecto, fecha, id_usuario, id_estado_lista_corte, nro_revision, anulado, nombre, numero, descripcion, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)";
+  $params = [
+    $datos['id_lista_corte'],
+    $datos['id_proyecto'],
+    $datos['fecha'],
+    $datos['id_usuario'],
+    $datos['id_estado_lista_corte'] ?? 1,
+    $datos['nro_revision'],
+    $datos['anulado'] ?? 0,
+    $datos['nombre'],
+    $datos['numero'],
+    $datos['descripcion'],
+    $datos['id_cuenta_realizo'],
+    $datos['id_cuenta_reviso'],
+    $datos['id_cuenta_valido']
+  ];
+  $stmt = $pdo->prepare($sql);
+  $stmt->execute($params);
+  $id = (int)$pdo->lastInsertId();
+
+  if (!empty($datos['adjunto'])) {
+    $pdo->prepare('UPDATE listas_corte_revisiones SET adjunto = ? WHERE id = ?')->execute([$datos['adjunto'], $id]);
+  }
+
+  return $id;
+}
+
+/**
+ * Duplica conjuntos, posiciones y procesos de una revisión de lista de corte en otra.
+ */
+function duplicarListaCorteRevision(PDO $pdo, int $idOrigen, int $idDestino, bool $modoDebug = false): void {
+  $sqlCon = "SELECT id, nombre, cantidad, peso, id_estado_lista_corte_conjuntos FROM listas_corte_conjuntos WHERE id_lista_corte = ?";
+  $stmtCon = $pdo->prepare($sqlCon);
+  $stmtCon->execute([$idOrigen]);
+  while ($conj = $stmtCon->fetch(PDO::FETCH_ASSOC)) {
+    $pdo->prepare(
+      'INSERT INTO listas_corte_conjuntos (id_lista_corte, nombre, cantidad, peso, id_estado_lista_corte_conjuntos) VALUES (?,?,?,?,?)'
+    )->execute([$idDestino, $conj['nombre'], $conj['cantidad'], $conj['peso'], $conj['id_estado_lista_corte_conjuntos']]);
+    $idConjNuevo = (int)$pdo->lastInsertId();
+
+    $stmtPos = $pdo->prepare(
+      'SELECT id, id_material, posicion, cantidad, largo, ancho, marca, peso, finalizado, id_colada, diametro, calidad FROM lista_corte_posiciones WHERE id_lista_corte_conjunto = ?'
+    );
+    $stmtPos->execute([$conj['id']]);
+    while ($pos = $stmtPos->fetch(PDO::FETCH_ASSOC)) {
+      $pdo->prepare(
+        'INSERT INTO lista_corte_posiciones (id_lista_corte_conjunto, id_material, posicion, cantidad, largo, ancho, marca, peso, finalizado, id_colada, diametro, calidad) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)'
+      )->execute([
+        $idConjNuevo,
+        $pos['id_material'],
+        $pos['posicion'],
+        $pos['cantidad'],
+        $pos['largo'],
+        $pos['ancho'],
+        $pos['marca'],
+        $pos['peso'],
+        $pos['finalizado'],
+        $pos['id_colada'],
+        $pos['diametro'],
+        $pos['calidad']
+      ]);
+      $idPosNuevo = (int)$pdo->lastInsertId();
+
+      $stmtProc = $pdo->prepare(
+        'SELECT id_tipo_proceso, observaciones, id_estado_lista_corte_proceso FROM lista_corte_procesos WHERE id_lista_corte_posicion = ?'
+      );
+      $stmtProc->execute([$pos['id']]);
+      while ($proc = $stmtProc->fetch(PDO::FETCH_ASSOC)) {
+        $pdo->prepare(
+          'INSERT INTO lista_corte_procesos (id_lista_corte_posicion, id_tipo_proceso, observaciones, id_estado_lista_corte_proceso) VALUES (?,?,?,?)'
+        )->execute([
+          $idPosNuevo,
+          $proc['id_tipo_proceso'],
+          $proc['observaciones'],
+          $proc['id_estado_lista_corte_proceso']
+        ]);
+      }
+    }
+  }
+}

--- a/modificarListaCorte.php
+++ b/modificarListaCorte.php
@@ -112,78 +112,27 @@ if (!empty($_POST)) {
     $q = $pdo->prepare($sql);
     $q->execute([$id_lista_corte_revision]);
    
-    $sql = "INSERT INTO listas_corte_revisiones (id_lista_corte, id_proyecto, fecha, id_usuario, id_estado_lista_corte, nro_revision, anulado, nombre, numero, descripcion, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)";
-    $q = $pdo->prepare($sql);
-    $q->execute([$data["id_lista_corte"],$data['id_proyecto'],$_POST['fecha'],$data['id_usuario'],1,$nuevo_nro_revision,$data['anulado'],$_POST['nombre'],$_POST['numero'],$_POST['descripcion'],$_POST['id_cuenta_realizo'],$_POST['id_cuenta_reviso'],$_POST['id_cuenta_valido']]);
-    $id_lista_corte_revision = $pdo->lastInsertId();
+    $id_lista_corte_revision = crearListaCorteRevision($pdo, [
+      'id_lista_corte'   => $data['id_lista_corte'],
+      'id_proyecto'      => $data['id_proyecto'],
+      'fecha'            => $_POST['fecha'],
+      'id_usuario'       => $data['id_usuario'],
+      'nro_revision'     => $nuevo_nro_revision,
+      'anulado'          => $data['anulado'],
+      'nombre'           => $_POST['nombre'],
+      'numero'           => $_POST['numero'],
+      'descripcion'      => $_POST['descripcion'],
+      'id_cuenta_realizo'=> $_POST['id_cuenta_realizo'],
+      'id_cuenta_reviso' => $_POST['id_cuenta_reviso'],
+      'id_cuenta_valido' => $_POST['id_cuenta_valido'],
+      'adjunto'          => $_POST['adjunto'] ?? null
+    ]);
 
     if ($modoDebug==1) {
-      $q->debugDumpParams();
-      echo "<br><br>Afe: ".$q->rowCount();
-      echo "<br><br>";
+      echo "<br><br>Creada nueva revisión ID: $id_lista_corte_revision<br><br>";
     }
-	/*
-    if (!empty($_FILES['adjunto']['name'])) {
-      $filename = $_FILES['adjunto']['name'];
-      move_uploaded_file($_FILES['adjunto']['tmp_name'],'adjuntos_lc/'.$id_lista_corte_revision.'_'.$filename);
-        
-      $sql = "UPDATE listas_corte_revisiones set adjunto = ? where id = ?";
-      $q = $pdo->prepare($sql);
-      $q->execute(array($id_lista_corte_revision.'_'.$filename,$id_lista_corte_revision));
 
-      if ($modoDebug==1) {
-        $q->debugDumpParams();
-        echo "<br><br>Afe: ".$q->rowCount();
-        echo "<br><br>";
-      }
-    }
-	*/
-	if (!empty($_POST['adjunto'])) {
-      $sql = "UPDATE listas_corte_revisiones set adjunto = ? where id = ?";
-      $q = $pdo->prepare($sql);
-      $q->execute(array($_POST['adjunto'],$id_lista_corte_revision));
-    }
-	
-    $sql = "SELECT lcc.id,lcc.id_lista_corte,lcc.nombre,lcc.cantidad,lcc.peso,lcc.id_estado_lista_corte_conjuntos FROM listas_corte_conjuntos lcc WHERE lcc.id_lista_corte = ".$data['id'];
-    foreach ($pdo->query($sql) as $row) {
-      $sql = "INSERT INTO listas_corte_conjuntos (id_lista_corte, nombre, cantidad, peso, id_estado_lista_corte_conjuntos) VALUES (?,?,?,?,?)";
-      $q = $pdo->prepare($sql);
-      $q->execute([$id_lista_corte_revision,$row['nombre'],$row['cantidad'],$row['peso'],$row['id_estado_lista_corte_conjuntos']]);
-      $id_lista_corte_conjunto = $pdo->lastInsertId();
-
-      if ($modoDebug==1) {
-        $q->debugDumpParams();
-        echo "<br><br>Afe: ".$q->rowCount();
-        echo "<br><br>";
-      }
-
-      $sql = "SELECT lcp.id,lcp.id_lista_corte_conjunto,lcp.id_material,lcp.posicion,lcp.cantidad,lcp.largo,lcp.ancho,lcp.marca,lcp.peso,lcp.finalizado,lcp.id_colada,lcp.diametro,lcp.calidad FROM lista_corte_posiciones lcp WHERE lcp.id_lista_corte_conjunto = ".$row["id"];
-      foreach ($pdo->query($sql) as $row) {
-        $sql = "INSERT INTO lista_corte_posiciones (id_lista_corte_conjunto,id_material,posicion,cantidad,largo,ancho,marca,peso,finalizado,id_colada,diametro,calidad) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)";
-        $q = $pdo->prepare($sql);
-        $q->execute([$id_lista_corte_conjunto,$row["id_material"],$row["posicion"],$row["cantidad"],$row["largo"],$row["ancho"],$row["marca"],$row["peso"],$row["finalizado"],$row["id_colada"],$row["diametro"],$row["calidad"]]);
-        $id_lista_corte_posicion = $pdo->lastInsertId();
-
-        if ($modoDebug==1) {
-          $q->debugDumpParams();
-          echo "<br><br>Afe: ".$q->rowCount();
-          echo "<br><br>";
-        }
-
-        $sql = "SELECT lcp.id_lista_corte_posicion,lcp.id_tipo_proceso,lcp.observaciones,lcp.id_estado_lista_corte_proceso FROM lista_corte_procesos lcp WHERE lcp.id_lista_corte_posicion = ".$row["id"];
-        foreach ($pdo->query($sql) as $row) {
-          $sql = "INSERT INTO lista_corte_procesos (id_lista_corte_posicion, id_tipo_proceso, observaciones, id_estado_lista_corte_proceso) VALUES (?,?,?,?)";
-          $q = $pdo->prepare($sql);
-          $q->execute([$id_lista_corte_posicion,$row['id_tipo_proceso'],$row['observaciones'],$row['id_estado_lista_corte_proceso']]);
-
-          if ($modoDebug==1) {
-            $q->debugDumpParams();
-            echo "<br><br>Afe: ".$q->rowCount();
-            echo "<br><br>";
-          }
-        }
-      }
-    }
+    duplicarListaCorteRevision($pdo, (int)$data['id'], $id_lista_corte_revision, (bool)$modoDebug);
 
     $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo) VALUES (now(),?,'Nueva Revision de Lista de Corte','Listas de Corte')";
     $q = $pdo->prepare($sql);

--- a/nuevaListaCorte.php
+++ b/nuevaListaCorte.php
@@ -44,25 +44,28 @@ if (!empty($_POST)) {
   $idCuentaReviso  = $_POST['id_cuenta_reviso'] ?? null;
   $idCuentaValido  = $_POST['id_cuenta_valido'] ?? null;
 
-	$sql = "SELECT id FROM cuentas WHERE id_usuario = ? ";
-	$q = $pdo->prepare($sql);
-	$q->execute([$_SESSION['user']['id']]);
-	$data = $q->fetch(PDO::FETCH_ASSOC);
-	if (!empty($data)) {
-		$idCuentaRealizo = $data['id'];
-	}
+        $sql = "SELECT id FROM cuentas WHERE id_usuario = ? ";
+        $q = $pdo->prepare($sql);
+        $q->execute([$_SESSION['user']['id']]);
+        $data = $q->fetch(PDO::FETCH_ASSOC);
+        if (!empty($data)) {
+                $idCuentaRealizo = $data['id'];
+        }
 
-  $sql = "INSERT INTO listas_corte_revisiones (id_lista_corte, id_proyecto, fecha, id_usuario, id_estado_lista_corte, nro_revision, anulado, nombre, numero, descripcion, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido) VALUES (?,?,?,?,1,0,0,?,?,?,?,?,?)";
-  $q = $pdo->prepare($sql);
-  $q->execute([$id_lista_corte,$_POST['id_proyecto'],$_POST['fecha'],$_SESSION['user']['id'],$_POST['nombre'],$_POST['numero'],"Emisión original",$idCuentaRealizo,$idCuentaReviso,$idCuentaValido]);
-
-  $id_lista_corte_revision = $pdo->lastInsertId();
-  
-  if (!empty($_POST['adjunto'])) {
-    $sql = "UPDATE listas_corte_revisiones set adjunto = ? where id = ?";
-    $q = $pdo->prepare($sql);
-    $q->execute(array($_POST['adjunto'],$id_lista_corte_revision));
-  }
+  $id_lista_corte_revision = crearListaCorteRevision($pdo, [
+    'id_lista_corte'   => $id_lista_corte,
+    'id_proyecto'      => $_POST['id_proyecto'],
+    'fecha'            => $_POST['fecha'],
+    'id_usuario'       => $_SESSION['user']['id'],
+    'nro_revision'     => 0,
+    'nombre'           => $_POST['nombre'],
+    'numero'           => $_POST['numero'],
+    'descripcion'      => 'Emisión original',
+    'id_cuenta_realizo'=> $idCuentaRealizo,
+    'id_cuenta_reviso' => $idCuentaReviso,
+    'id_cuenta_valido' => $idCuentaValido,
+    'adjunto'          => $_POST['adjunto'] ?? null
+  ]);
   
   
   $sql = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (now(),?,'Nueva Lista de Corte','Listas de Corte','imprimirListaCorte.php?id=$id_lista_corte_revision')";


### PR DESCRIPTION
## Summary
- add `crearListaCorteRevision` and `duplicarListaCorteRevision` helpers
- use shared helper in `nuevaListaCorte.php`
- reuse helper and duplication routine in `modificarListaCorte.php`

## Testing
- `php -l nuevaListaCorte.php`
- `php -l modificarListaCorte.php`
- `php -l funciones.php`
- `php -l tests/aprobarComputos.php`


------
https://chatgpt.com/codex/tasks/task_e_68815e079e3883218bc0e331b359da54