### PR TITLE
Fix redirect parameter in eliminarConjuntoListaCorte.php

### DIFF
--- a/eliminarConjuntoListaCorte.php
+++ b/eliminarConjuntoListaCorte.php
@@ -34,4 +34,4 @@ $q->execute(array($_SESSION['user']['id']));
 
 Database::disconnect();
     
-header("Location: nuevaListaCorteConjuntos.php?id_lista_corte_revision=".$data["id_lista_corte"]);
+header("Location: nuevaListaCorteConjuntos.php?id_lista_corte=".$data["id_lista_corte"]);


### PR DESCRIPTION
## Summary
- fix redirect GET parameter to `id_lista_corte` after deleting a conjunto

## Testing
- `php -l eliminarConjuntoListaCorte.php`
- `php -l nuevaListaCorteConjuntos.php`


------
https://chatgpt.com/codex/tasks/task_e_688d1bf35f908321980a7278180a6c41