### PR TITLE
Add task selection in LC cloning modal

### DIFF
--- a/clonarListaCorte.php
+++ b/clonarListaCorte.php
@@ -32,6 +32,10 @@ if ($modoDebug==1) {
 
 
 $id_lista_corte_clonar = $_GET['id_lista_corte'];
+$id_tarea_nueva = null;
+if (!empty($_GET['id_tarea'])) {
+  $id_tarea_nueva = (int)$_GET['id_tarea'];
+}
 
 $sql = "SELECT id_proyecto, id_tarea, fecha, id_usuario, id_estado_lista_corte, anulado, nombre, descripcion, adjunto, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido FROM listas_corte WHERE id = ?";
 $q = $pdo->prepare($sql);
@@ -45,9 +49,20 @@ if ($modoDebug==1) {
 }
 
 
+$id_proyecto_destino = $data['id_proyecto'];
+if ($id_tarea_nueva) {
+  $sql = "SELECT id_proyecto FROM tareas WHERE id = ?";
+  $q = $pdo->prepare($sql);
+  $q->execute([$id_tarea_nueva]);
+  $tarea = $q->fetch(PDO::FETCH_ASSOC);
+  if (!empty($tarea['id_proyecto'])) {
+    $id_proyecto_destino = (int)$tarea['id_proyecto'];
+  }
+}
+
 $sql = "SELECT MAX(numero) AS max_num FROM listas_corte WHERE id_proyecto = ?";
 $q = $pdo->prepare($sql);
-$q->execute([$data['id_proyecto']]);
+$q->execute([$id_proyecto_destino]);
 $cant = $q->fetch(PDO::FETCH_ASSOC);
 $numero_lc = ((int)$cant['max_num']) + 1;
 
@@ -60,8 +75,8 @@ if ($modoDebug==1) {
 $sql = "INSERT INTO listas_corte (id_proyecto, id_tarea, fecha, id_usuario, id_estado_lista_corte, nro_revision, anulado, nombre, numero, adjunto, descripcion, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 $q = $pdo->prepare($sql);
 $q->execute([
-  $data['id_proyecto'],
-  $data['id_tarea'],
+  $id_proyecto_destino,
+  $id_tarea_nueva ? $id_tarea_nueva : $data['id_tarea'],
   $data['fecha'],
   $data['id_usuario'],
   1,

--- a/listarListasCorte.php
+++ b/listarListasCorte.php
@@ -308,6 +308,24 @@ include 'database.php';?>
           </div>
           <div class="modal-body">
             <p id="textoClonar">¿Está seguro?</p>
+            <select id="select_tarea_clonar" class="js-example-basic-single col-sm-12" style="width:100%; margin-top:10px;">
+              <option value="">Seleccione una tarea...</option>
+              <?php
+                $pdo = Database::connect();
+                $sqlT = "SELECT t.id, s.nro_sitio, s.nro_subsitio, p.nro, p.nombre, tt.tipo, t.observaciones
+                          FROM tareas t
+                          INNER JOIN proyectos p ON p.id = t.id_proyecto
+                          INNER JOIN sitios s ON s.id = p.id_sitio
+                          INNER JOIN tipos_tarea tt ON tt.id = t.id_tipo_tarea
+                          WHERE t.anulado = 0 AND p.anulado = 0
+                          ORDER BY s.nro_sitio, s.nro_subsitio, p.nro, t.id";
+                foreach ($pdo->query($sqlT) as $filaT) {
+                  $desc = $filaT['nro_sitio'].'-'.$filaT['nro_subsitio'].'-'.$filaT['nro'].': '.$filaT['nombre'].' / '.$filaT['tipo'].' - '.$filaT['observaciones'];
+                  echo "<option value='{$filaT['id']}'>".$desc."</option>";
+                }
+                Database::disconnect();
+              ?>
+            </select>
           </div>
           <div class="modal-footer">
             <a id="btnConfirmarClonar" class="btn btn-primary" href="#">Confirmar</a>
@@ -518,7 +536,15 @@ include 'database.php';?>
 
           const mensaje = `¿Desea clonar la Lista de Corte #${numero} Rev. ${revision} del proyecto ${proyecto} (${sitio}/${subsitio}/${proy})?`;
           $("#textoClonar").text(mensaje);
-          $("#btnConfirmarClonar").attr("href",`clonarListaCorte.php?id_lista_corte=${id}&revision=${revision}`);
+          $("#btnConfirmarClonar").off('click').on('click', function(ev){
+            ev.preventDefault();
+            const idTarea = $('#select_tarea_clonar').val();
+            if(!idTarea){
+              alert('Debe seleccionar una tarea');
+              return;
+            }
+            window.location.href = `clonarListaCorte.php?id_lista_corte=${id}&revision=${revision}&id_tarea=${idTarea}`;
+          });
           $("#modalClonar").modal("show");
         })
         $("#link_nuevo_conjunto").on("click",function(){


### PR DESCRIPTION
## Summary
- add a select2 dropdown with project tasks in the clone LC modal
- update JS to send selected task when cloning
- allow `clonarListaCorte.php` to accept `id_tarea` and set its project

## Testing
- `php -l listarListasCorte.php`
- `php -l clonarListaCorte.php`


------
https://chatgpt.com/codex/tasks/task_e_688d15be30708321b2fa6b6f2fdb8005