### PR TITLE
Pre-populate OT transfer quantity with saldo and enforce limits

### DIFF
--- a/nuevaOrdenTrabajo.php
+++ b/nuevaOrdenTrabajo.php
@@ -409,14 +409,16 @@ Database::disconnect();?>
           var selectedRowsLC = tablaLC.DataTable().rows('.selected');
           if(selectedRowsLC[0].length>0){
             let newData=selectedRowsLC.data().map(function(elemento){
-              elemento[5] = `
+              let saldo = elemento[8];
+              let inputCantidad = `
                 <input type="hidden" name="id_posicion[]" value="${elemento["DT_RowId"]}">
-                <input type="number" step="0.01" class="form-control" name="cantidad_bajar[]">
+                <input type="number" step="0.01" class="form-control cantidad-bajar" name="cantidad_bajar[]" value="${saldo}" data-saldo="${saldo}" max="${saldo}" min="0">
+                <div class="invalid-feedback">La cantidad no puede superar el saldo (${saldo}).</div>
               `;
-              return elemento;
+              return [elemento[0], elemento[1], elemento[2], elemento[3], elemento[4], inputCantidad];
             })
             tablaOT.DataTable().rows.add(newData).draw();
-            $(selectedRowsLC.nodes()).hide().removeClass("selected")
+            $(selectedRowsLC.nodes()).hide().removeClass("selected");
 
           }else{
             alert("Por favor seleccione una posicion para agregar a la Orden de trabajo")
@@ -490,12 +492,23 @@ Database::disconnect();?>
             });
             //$(selectedRowsOT.nodes()).remove().draw();
             selectedRowsOT.remove().draw();
-  
+
           }else{
             alert("Por favor seleccione una posicion para eliminar")
           }
         });
-    
+
+        $(document).on('input', '.cantidad-bajar', function(){
+          var saldo = parseFloat($(this).data('saldo'));
+          var valor = parseFloat($(this).val());
+          if(valor > saldo){
+            $(this).val(saldo);
+            $(this).addClass('is-invalid');
+          }else{
+            $(this).removeClass('is-invalid');
+          }
+        });
+
       });
 	  
 	    function order(a, b) {


### PR DESCRIPTION
## Summary
- Autofill quantity input during OT row transfer with the row's remaining saldo and expose inline alert
- Add client-side validation clamping quantity to saldo while surfacing invalid styling

## Testing
- `php -l nuevaOrdenTrabajo.php`


------
https://chatgpt.com/codex/tasks/task_e_689351bd282483218da1845184958602