### PR TITLE
feat: duplicate lista corte revision

### DIFF
--- a/funciones.php
+++ b/funciones.php
@@ -626,28 +626,28 @@ function duplicarListaCorteRevision(PDO $pdo, int $idOrigen, int $idDestino, boo
   $stmtCon = $pdo->prepare($sqlCon);
   $stmtCon->execute([$idOrigen]);
   while ($conj = $stmtCon->fetch(PDO::FETCH_ASSOC)) {
-    $sql = 'INSERT INTO listas_corte_conjuntos (id_lista_corte, nombre, cantidad, peso, id_estado_lista_corte_conjuntos) VALUES (?,?,?,?,?)';
+    $sql = 'INSERT INTO listas_corte_conjuntos (id_lista_corte, nombre, cantidad, peso, id_estado_lista_corte_conjuntos) VALUES(?,?,?,?,?)';
     $q = $pdo->prepare($sql);
     $params = [$idDestino, $conj['nombre'], $conj['cantidad'], $conj['peso'], $conj['id_estado_lista_corte_conjuntos']];
-    if ($modoDebug==1) {
-      //$q->debugDumpParams();
-      echo debugQuery($pdo,$sql,$params);
-      echo "<br><br>Afe: ".$q->rowCount();
-      echo "<br><br>";
+    if ($modoDebug) {
+      echo debugQuery($pdo, $sql, $params) . "<br>";
     }
     $q->execute($params);
+    if ($modoDebug) {
+      echo "Afe: " . $q->rowCount() . "<br><br>";
+    }
     $idConjNuevo = (int)$pdo->lastInsertId();
 
     $sql = 'SELECT id, id_material, posicion, cantidad, largo, ancho, marca, peso, peso_calculado_posicion, finalizado, id_colada, diametro, calidad FROM lista_corte_posiciones WHERE id_lista_corte_conjunto = ?';
     $stmtPos = $pdo->prepare($sql);
     $params = [$conj['id']];
-    if ($modoDebug==1) {
-      //$q->debugDumpParams();
-      echo debugQuery($pdo,$sql,$params);
-      echo "<br><br>Afe: ".$q->rowCount();
-      echo "<br><br>";
+    if ($modoDebug) {
+      echo debugQuery($pdo, $sql, $params) . "<br>";
     }
     $stmtPos->execute($params);
+    if ($modoDebug) {
+      echo "Afe: " . $stmtPos->rowCount() . "<br><br>";
+    }
     while ($pos = $stmtPos->fetch(PDO::FETCH_ASSOC)) {
       $sql = 'INSERT INTO lista_corte_posiciones (id_lista_corte_conjunto, id_material, posicion, cantidad, largo, ancho, marca, peso, peso_calculado_posicion, finalizado, id_colada, diametro, calidad) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)';
       $q = $pdo->prepare($sql);
@@ -666,25 +666,25 @@ function duplicarListaCorteRevision(PDO $pdo, int $idOrigen, int $idDestino, boo
         $pos['diametro'],
         $pos['calidad']
       ];
-      if ($modoDebug==1) {
-        //$q->debugDumpParams();
-        echo debugQuery($pdo,$sql,$params);
-        echo "<br><br>Afe: ".$q->rowCount();
-        echo "<br><br>";
+      if ($modoDebug) {
+        echo debugQuery($pdo, $sql, $params) . "<br>";
       }
       $q->execute($params);
+      if ($modoDebug) {
+        echo "Afe: " . $q->rowCount() . "<br><br>";
+      }
       $idPosNuevo = (int)$pdo->lastInsertId();
 
       $sql = 'SELECT id_tipo_proceso, observaciones, id_estado_lista_corte_proceso FROM lista_corte_procesos WHERE id_lista_corte_posicion = ?';
       $stmtProc = $pdo->prepare($sql);
       $params = [$pos['id']];
-      if ($modoDebug==1) {
-        //$q->debugDumpParams();
-        echo debugQuery($pdo,$sql,$params);
-        echo "<br><br>Afe: ".$q->rowCount();
-        echo "<br><br>";
+      if ($modoDebug) {
+        echo debugQuery($pdo, $sql, $params) . "<br>";
       }
       $stmtProc->execute($params);
+      if ($modoDebug) {
+        echo "Afe: " . $stmtProc->rowCount() . "<br><br>";
+      }
       while ($proc = $stmtProc->fetch(PDO::FETCH_ASSOC)) {
         $sql = 'INSERT INTO lista_corte_procesos (id_lista_corte_posicion, id_tipo_proceso, observaciones, id_estado_lista_corte_proceso) VALUES (?,?,?,?)';
         $q = $pdo->prepare($sql);
@@ -694,14 +694,15 @@ function duplicarListaCorteRevision(PDO $pdo, int $idOrigen, int $idDestino, boo
           $proc['observaciones'],
           $proc['id_estado_lista_corte_proceso']
         ];
-        if ($modoDebug==1) {
-          //$q->debugDumpParams();
-          echo debugQuery($pdo,$sql,$params);
-          echo "<br><br>Afe: ".$q->rowCount();
-          echo "<br><br>";
+        if ($modoDebug) {
+          echo debugQuery($pdo, $sql, $params) . "<br>";
         }
         $q->execute($params);
+        if ($modoDebug) {
+          echo "Afe: " . $q->rowCount() . "<br><br>";
+        }
       }
     }
   }
 }
+

--- a/nuevaRevisionListaCorte.php
+++ b/nuevaRevisionListaCorte.php
@@ -17,26 +17,37 @@
     }
     
     if (!empty($_POST)) {
-        
-        // insert data
         $pdo = Database::connect();
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-        
-        $sql = "UPDATE `listas_corte` set `nro_revision` = `nro_revision` + 1 where id = ?";
-        $q = $pdo->prepare($sql);
-        $q->execute([$_GET['id']]);
-		
-		$sql = "INSERT INTO `listas_corte_revisiones`(`id_lista_corte`, `nro_revision`, `comentarios`, `fecha_hora`, `fecha_hora`) VALUES (?,?,?,now())";
-		$q = $pdo->prepare($sql);
-		$q->execute([$_GET['id'],$_POST['nro_revision']+1,$_POST['comentarios']]);
-		
-		$sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Nueva revisión de lista de corte','Listas de Corte','imprimirListaCorte.php?id=$id')";
-		$q = $pdo->prepare($sql);
-		$q->execute(array($_SESSION['user']['id']));
 
-        
+        // Datos de la revisión actual
+        $sql = "SELECT id_proyecto, id_tarea, fecha, id_usuario, id_estado_lista_corte, nro_revision, anulado, nombre, numero, adjunto, descripcion, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido FROM listas_corte WHERE id = ?";
+        $q = $pdo->prepare($sql);
+        $q->execute([$id]);
+        $data = $q->fetch(PDO::FETCH_ASSOC);
+
+        // Crear nueva revisión duplicando los datos anteriores
+        $nuevoNro = $data['nro_revision'] + 1;
+        $sql = "INSERT INTO listas_corte (id_proyecto, id_tarea, fecha, id_usuario, id_estado_lista_corte, nro_revision, anulado, nombre, numero, adjunto, descripcion, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+        $params = [$data['id_proyecto'], $data['id_tarea'], $data['fecha'], $data['id_usuario'], $data['id_estado_lista_corte'], $nuevoNro, $data['anulado'], $data['nombre'], $data['numero'], $data['adjunto'], $data['descripcion'], $data['id_cuenta_realizo'], $data['id_cuenta_reviso'], $data['id_cuenta_valido']];
+        $q = $pdo->prepare($sql);
+        $q->execute($params);
+        $idNueva = $pdo->lastInsertId();
+
+        // Copiar conjuntos y posiciones
+        duplicarListaCorteRevision($pdo, $id, $idNueva);
+
+        // Registrar en logs
+        $detalle = 'Nueva revisión de lista de corte';
+        if (!empty($_POST['comentarios'])) {
+            $detalle .= ' - ' . $_POST['comentarios'];
+        }
+        $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (now(),?,?,'Listas de Corte','imprimirListaCorte.php?id=$idNueva')";
+        $q = $pdo->prepare($sql);
+        $q->execute([$_SESSION['user']['id'], $detalle]);
+
         Database::disconnect();
-        
+
         header("Location: listarListasCorte.php");
     } else {
         $pdo = Database::connect();
@@ -85,7 +96,6 @@
 						  <div class="form-group row">
 							<label class="col-sm-3 col-form-label">Comentarios</label>
 							<div class="col-sm-9"><textarea name="comentarios" class="form-control" autofocus></textarea></div>
-							<input type="hidden" name="nro_revision" value="<?php echo $_GET['revision'];?>">
 						  </div>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- allow generating new lista de corte revision by copying previous data
- improve duplicarListaCorteRevision debug output

## Testing
- `php -l nuevaRevisionListaCorte.php`
- `php -l funciones.php`


------
https://chatgpt.com/codex/tasks/task_e_6893512abac48321875b49f5487d73e2