### PR TITLE
Validate OT quantity against available saldo

### DIFF
--- a/nuevaOrdenTrabajo.php
+++ b/nuevaOrdenTrabajo.php
@@ -6,6 +6,14 @@ if (empty($_SESSION['user'])) {
 }
 require 'database.php';
 $modoDebug=0;
+
+function obtenerSaldoPosicion($pdo,$id_posicion){
+  $sql = "SELECT lcp.cantidad AS cant_pos, COALESCE(SUM(otd.cantidad),0) AS cant_bajada FROM lista_corte_posiciones lcp LEFT JOIN ordenes_trabajo_detalle otd ON otd.id_posicion=lcp.id WHERE lcp.id = ? GROUP BY lcp.id";
+  $q = $pdo->prepare($sql);
+  $q->execute([$id_posicion]);
+  $data = $q->fetch(PDO::FETCH_ASSOC);
+  return $data ? $data['cant_pos'] - $data['cant_bajada'] : 0;
+}
 if (!empty($_POST)) {
 
   // insert data
@@ -76,11 +84,19 @@ if (!empty($_POST)) {
   }*/
 
   foreach ($_POST["cantidad_bajar"] as $key => $cantidad) {
-    if($cantidad!="" and $cantidad>0){
+    if($cantidad!=""){
+      $id_posicion = $_POST['id_posicion'][$key];
+      $saldo = obtenerSaldoPosicion($pdo,$id_posicion);
+      if(!is_numeric($cantidad) || $cantidad <= 0 || $cantidad > $saldo){
+        $pdo->rollBack();
+        Database::disconnect();
+        header("Location: nuevaOrdenTrabajo.php?error=1&id_lista_corte=".$id_lista_corte);
+        exit;
+      }
       $id_estado_orden_trabajo_posicion=1;//Elaboración, Pendiente, Proceso, Terminada, Liberada, Reproceso, Rechazada, Cancelada
 
       $sql = "INSERT INTO ordenes_trabajo_detalle (id_orden_trabajo, id_posicion, cantidad, id_estado_orden_trabajo_posicion) VALUES (?,?,?,?)";
-      $params = [$id_orden_trabajo,$_POST['id_posicion'][$key],$cantidad,$id_estado_orden_trabajo_posicion];
+      $params = [$id_orden_trabajo,$id_posicion,$cantidad,$id_estado_orden_trabajo_posicion];
       $q = $pdo->prepare($sql);
       $q->execute($params);
       if ($modoDebug==1) {
@@ -145,6 +161,9 @@ Database::disconnect();?>
           <div class="container-fluid">
             <div class="row">
               <div class="col-sm-12">
+                <?php if(isset($_GET['error']) && $_GET['error']==1){?>
+                <div class="alert alert-danger">La cantidad a bajar debe ser un número positivo y no superar el saldo disponible.</div>
+                <?php }?>
                 <form class="form theme-form" role="form" method="post" action="nuevaOrdenTrabajo.php">
                   <div class="card mb-0">
                     <div class="card-header">

--- a/tests/nuevaOrdenTrabajoInvalidQuantity.php
+++ b/tests/nuevaOrdenTrabajoInvalidQuantity.php
@@ -1,0 +1,17 @@
+<?php
+function validarCantidad($saldo, $cantidad){
+    return is_numeric($cantidad) && $cantidad > 0 && $cantidad <= $saldo;
+}
+
+$casos = [
+    ['saldo'=>10, 'cantidad'=>5, 'esperado'=>true],
+    ['saldo'=>10, 'cantidad'=>0, 'esperado'=>false],
+    ['saldo'=>10, 'cantidad'=>-3, 'esperado'=>false],
+    ['saldo'=>10, 'cantidad'=>11, 'esperado'=>false],
+];
+
+foreach($casos as $c){
+    $resultado = validarCantidad($c['saldo'], $c['cantidad']);
+    echo "saldo={$c['saldo']} cantidad={$c['cantidad']} => ".($resultado?'true':'false')." esperado=".($c['esperado']?'true':'false')."\n";
+}
+?>


### PR DESCRIPTION
## Summary
- validate OT detail quantities against available saldo
- show error when quantity exceeds available or is non-positive
- add script testing invalid quantity scenarios

## Testing
- `php -l nuevaOrdenTrabajo.php`
- `php -l tests/nuevaOrdenTrabajoInvalidQuantity.php`
- `php tests/nuevaOrdenTrabajoInvalidQuantity.php`


------
https://chatgpt.com/codex/tasks/task_e_6894b6b3af308321af39ff272b366821