### PR TITLE
Sanitize list IDs and parameterize queries

### DIFF
--- a/nuevaListaCorteConjuntos.php
+++ b/nuevaListaCorteConjuntos.php
@@ -7,8 +7,11 @@ if (empty($_SESSION['user'])) {
 require 'database.php';
 
 if(isset($_GET["id_lista_corte"])){
-  $id_lista_corte=$_GET["id_lista_corte"];
+  $id_lista_corte = filter_input(INPUT_GET, 'id_lista_corte', FILTER_VALIDATE_INT);
 } else {
+  $id_lista_corte = false;
+}
+if (!$id_lista_corte) {
   header("Location: listarListasCorte.php");
   die("Redirecting to listarListasCorte.php");
 }
@@ -27,11 +30,11 @@ if (!empty($_POST)) {
   if (isset($_POST['btn2']) or isset($_POST['btn3'])) {
 
     if(isset($_POST['btn2'])){
-      $id_lista_corte_conjunto=$_POST['btn2'];
+      $id_lista_corte_conjunto = filter_input(INPUT_POST,'btn2',FILTER_VALIDATE_INT);
       $redirect="nuevaListaCorteConjuntos.php?id_lista_corte=".$id_lista_corte;
     }
     if(isset($_POST['btn3'])){
-      $id_lista_corte_conjunto=$_POST['btn3'];
+      $id_lista_corte_conjunto = filter_input(INPUT_POST,'btn3',FILTER_VALIDATE_INT);
       $redirect="nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto;
     }
 	
@@ -41,9 +44,10 @@ if (!empty($_POST)) {
 	$data = $q->fetch(PDO::FETCH_ASSOC);
 	
 	if ($data['cant'] == 0) {
-		$sql = "UPDATE listas_corte_conjuntos SET nombre = ?, cantidad = ? WHERE id = ?";
-		$q = $pdo->prepare($sql);
-		$q->execute([$_POST['nombre'],$_POST['cantidad'],$id_lista_corte_conjunto]);
+                $sql = "UPDATE listas_corte_conjuntos SET nombre = ?, cantidad = ? WHERE id = ?";
+                $q = $pdo->prepare($sql);
+                $cantidad = filter_input(INPUT_POST,'cantidad',FILTER_VALIDATE_FLOAT);
+                $q->execute([$_POST['nombre'],$cantidad,$id_lista_corte_conjunto]);
 		
 		$sql = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Modificacion de Conjunto ID #$id_lista_corte_conjunto de Lista de Corte','Listas de Corte','')";
 		$q = $pdo->prepare($sql);
@@ -65,7 +69,8 @@ if (!empty($_POST)) {
     if ($data['cant'] == 0) {
       $sql = "INSERT INTO listas_corte_conjuntos (id_lista_corte, nombre, cantidad, peso, id_estado_lista_corte_conjuntos) VALUES (?,?,?,?,?)";
       $q = $pdo->prepare($sql);
-      $q->execute([$id_lista_corte,$_POST['nombre'],$_POST['cantidad'],$peso,$id_estado_lista_corte_conjuntos]);
+      $cantidad = filter_input(INPUT_POST,'cantidad',FILTER_VALIDATE_FLOAT);
+      $q->execute([$id_lista_corte,$_POST['nombre'],$cantidad,$peso,$id_estado_lista_corte_conjuntos]);
       $id_lista_corte_conjunto = $pdo->lastInsertId();
       
       $sql = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Nuevo Conjunto ID #$id_lista_corte_conjunto de Lista de Corte','Listas de Corte','')";
@@ -162,8 +167,10 @@ Database::disconnect();?>
                                   $pdo = Database::connect();
                                   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
                                   
-                                  $sql = " SELECT c.id, c.nombre, c.cantidad, c.peso, e.estado FROM listas_corte_conjuntos c inner join estados_lista_corte_conjuntos e on e.id = c.id_estado_lista_corte_conjuntos WHERE c.id_lista_corte = ".$id_lista_corte;
-                                  foreach ($pdo->query($sql) as $row) {?>
+                                  $sql = " SELECT c.id, c.nombre, c.cantidad, c.peso, e.estado FROM listas_corte_conjuntos c inner join estados_lista_corte_conjuntos e on e.id = c.id_estado_lista_corte_conjuntos WHERE c.id_lista_corte = ?";
+                                  $q = $pdo->prepare($sql);
+                                  $q->execute([$id_lista_corte]);
+                                  while ($row = $q->fetch(PDO::FETCH_ASSOC)) {?>
                                     <tr>
                                       <td><?=$row["id"]?></td>
                                       <td><?=$row["nombre"]?></td>

--- a/nuevaOrdenTrabajo.php
+++ b/nuevaOrdenTrabajo.php
@@ -8,6 +8,7 @@ require 'database.php';
 $modoDebug=0;
 
 function obtenerSaldoPosicion($pdo,$id_posicion){
+  $id_posicion = intval($id_posicion);
   $sql = "SELECT lcp.cantidad AS cant_pos, COALESCE(SUM(otd.cantidad),0) AS cant_bajada FROM lista_corte_posiciones lcp LEFT JOIN ordenes_trabajo_detalle otd ON otd.id_posicion=lcp.id WHERE lcp.id = ? GROUP BY lcp.id";
   $q = $pdo->prepare($sql);
   $q->execute([$id_posicion]);
@@ -33,7 +34,7 @@ if (!empty($_POST)) {
   $anulado=0;
   $numero="";//insertamos vacío y una vez que obtenemos el ID lo modificamos
   $descripcion="Emision original";
-  $id_lista_corte=$_POST["id_lista_corte"];
+  $id_lista_corte = filter_input(INPUT_POST, 'id_lista_corte', FILTER_VALIDATE_INT);
 
   $sql = "SELECT max(nro_orden_trabajo) AS nro_orden_trabajo FROM ordenes_trabajo where id_lista_corte = ?";
   $q = $pdo->prepare($sql);
@@ -71,7 +72,7 @@ if (!empty($_POST)) {
   }*/
 
   /*if ($id_orden_trabajo>0) {
-    $numero="LC".$_POST["id_lista_corte"]."-OT".$id_orden_trabajo;
+    $numero="LC".$id_lista_corte."-OT".$id_orden_trabajo;
 
     $sql = "UPDATE ordenes_trabajo set numero = ? where id = ?";
     $params = [$numero,$id_orden_trabajo];
@@ -85,7 +86,7 @@ if (!empty($_POST)) {
 
   foreach ($_POST["cantidad_bajar"] as $key => $cantidad) {
     if($cantidad!=""){
-      $id_posicion = $_POST['id_posicion'][$key];
+      $id_posicion = intval($_POST['id_posicion'][$key]);
       $saldo = obtenerSaldoPosicion($pdo,$id_posicion);
       if(!is_numeric($cantidad) || $cantidad <= 0 || $cantidad > $saldo){
         $pdo->rollBack();
@@ -124,13 +125,14 @@ if (!empty($_POST)) {
 
 if(isset($_GET['id_lista_corte'])){
   //nueva revision
+  $id_lista_corte = filter_input(INPUT_GET, 'id_lista_corte', FILTER_VALIDATE_INT);
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
   //$sql = "SELECT id AS id_lista_corte_revision, nombre, numero, id_estado_lista_corte, descripcion, nro_revision, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido FROM listas_corte_revisiones WHERE id = ? ";
   $sql = "SELECT id AS id_lista_corte_revision, nombre, numero, id_estado_lista_corte, descripcion, nro_revision, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido FROM listas_corte WHERE id = ? ";
   $q = $pdo->prepare($sql);
-  $q->execute([$_GET['id_lista_corte']]);
+  $q->execute([$id_lista_corte]);
   $data = $q->fetch(PDO::FETCH_ASSOC);
 
 }
@@ -183,7 +185,7 @@ Database::disconnect();?>
                             </div>
                           </div> -->
                           <div class="form-group row">
-                            <input type="hidden" name="id_lista_corte" id="id_lista_corte" value="<?=$_GET['id_lista_corte']?>">
+                            <input type="hidden" name="id_lista_corte" id="id_lista_corte" value="<?=$id_lista_corte?>">
                             <label class="col-sm-3 col-form-label">Fecha(*)</label>
                             <div class="col-sm-3">
                               <input name="fecha" type="date" onfocus="this.showPicker()" value="<?php echo date('Y-m-d');?>" class="form-control">
@@ -267,8 +269,10 @@ Database::disconnect();?>
                               $pdo = Database::connect();
                               $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
                               
-                              $sql = " SELECT lcc.nombre,lcc.cantidad AS cant_conj,lcp.posicion,lcp.cantidad AS cant_pos,m.concepto,GROUP_CONCAT(tp.tipo SEPARATOR ',') AS procesos, lcp.id AS id_posicion,COALESCE(SUM(otd.cantidad),0) AS cant_bajada FROM listas_corte_conjuntos lcc INNER JOIN lista_corte_posiciones lcp ON lcp.id_lista_corte_conjunto=lcc.id INNER JOIN lista_corte_procesos lcpr ON lcpr.id_lista_corte_posicion=lcp.id INNER JOIN materiales m ON lcp.id_material=m.id INNER JOIN tipos_procesos tp ON lcpr.id_tipo_proceso=tp.id LEFT JOIN ordenes_trabajo_detalle otd ON otd.id_posicion=lcp.id WHERE lcc.id_lista_corte = ".$_GET['id_lista_corte']." GROUP BY lcp.id";
-                              foreach ($pdo->query($sql) as $row) {
+                                $sql = " SELECT lcc.nombre,lcc.cantidad AS cant_conj,lcp.posicion,lcp.cantidad AS cant_pos,m.concepto,GROUP_CONCAT(tp.tipo SEPARATOR ',' ) AS procesos, lcp.id AS id_posicion,COALESCE(SUM(otd.cantidad),0) AS cant_bajada FROM listas_corte_conjuntos lcc INNER JOIN lista_corte_posiciones lcp ON lcp.id_lista_corte_conjunto=lcc.id INNER JOIN lista_corte_procesos lcpr ON lcpr.id_lista_corte_posicion=lcp.id INNER JOIN materiales m ON lcp.id_material=m.id INNER JOIN tipos_procesos tp ON lcpr.id_tipo_proceso=tp.id LEFT JOIN ordenes_trabajo_detalle otd ON otd.id_posicion=lcp.id WHERE lcc.id_lista_corte = ? GROUP BY lcp.id";
+                                $q = $pdo->prepare($sql);
+                                $q->execute([$id_lista_corte]);
+                                while ($row = $q->fetch(PDO::FETCH_ASSOC)) {
                                 $saldo = $row["cant_pos"] - $row["cant_bajada"];?>
                                 <tr id="<?=$row["id_posicion"]?>" data-cant-bajada="<?=$row["cant_bajada"]?>" data-cant-pos="<?=$row["cant_pos"]?>">
                                   <td></td>


### PR DESCRIPTION
## Summary
- Sanitize work order and cut list IDs before database use
- Replace inline SQL concatenation with prepared statements

## Testing
- `php -l nuevaOrdenTrabajo.php`
- `php -l nuevaListaCorteConjuntos.php`


------
https://chatgpt.com/codex/tasks/task_e_6894b8b372888321985b1bcf99562343