### PR TITLE
Move approval button to conjuntos view

### DIFF
--- a/nuevaListaCorte.php
+++ b/nuevaListaCorte.php
@@ -388,11 +388,8 @@ if (!empty($_POST)) {
                     </div>
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
-                        <button class="btn btn-success" type="submit"><?=$accion?> y agregar Conjuntos</button><?php
-                         if($modo=="update"){?>
-                          <button class="btn btn-primary" type="button" id="btnEnviarAprobacion">Enviar a aprobación</button><?php
-                         }?>
-						            <a href="listarListasCorte.php" class="btn btn-light">Volver</a>
+                        <button class="btn btn-success" type="submit"><?=$accion?> y agregar Conjuntos</button>
+                        <a href="listarListasCorte.php" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>
@@ -404,26 +401,6 @@ if (!empty($_POST)) {
         </div>
         <!-- footer start-->
         <?php include("footer.php"); ?>
-      </div>
-    </div>
-
-    <div class="modal fade" id="modalEnviarAprobacion" tabindex="-1" role="dialog">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <form id="formEnviarAprobacion" method="post" action="enviarAprobacionListaCorte.php?id_lista_corte=<?=$id_lista_corte?>">
-            <div class="modal-header">
-              <h5 class="modal-title">Confirmar envío a aprobación</h5>
-              <button type="button" class="close" data-dismiss="modal">&times;</button>
-            </div>
-            <div class="modal-body">
-              <p>¿Estás seguro de que quieres enviar esta revisión a aprobación?</p>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-light" data-dismiss="modal">Cancelar</button>
-              <button type="submit" class="btn btn-primary">Confirmar</button>
-            </div>
-          </form>
-        </div>
       </div>
     </div>
 
@@ -470,15 +447,5 @@ if (!empty($_POST)) {
     <script src="assets/js/chat-menu.js"></script>
     <script src="assets/js/tooltip-init.js"></script>
     <!-- Plugins JS Ends-->
-    <script>
-      $(document).ready(function() {
-        
-        $('#btnEnviarAprobacion').on('click', function(){
-          $('#modalEnviarAprobacion').modal('show');
-        });
-  
-      });
-      
-      </script>
   </body>
 </html>

--- a/nuevaListaCorteConjuntos.php
+++ b/nuevaListaCorteConjuntos.php
@@ -211,6 +211,7 @@ Database::disconnect();?>
                         <button type="submit" value="2" name="btn2" id="editConjunto" class="btn btn-success d-none">Modificar</button>
                         <button type="submit" value="3" name="btn3" id="editConjuntoGoPosiciones" class="btn btn-primary d-none">Modificar e ir a Posiciones</button>
                         <button type="button" id="cancelEditConjunto" class="btn btn-light d-none">Cancelar Modificar</button>
+                        <button class="btn btn-primary" type="button" id="btnEnviarAprobacion">Enviar a aprobación</button>
                         <a href='listarListasCorte.php' id="volverListaCorte" class="btn btn-light">Volver al Listas de corte</a>
                       </div>
                     </div>
@@ -220,6 +221,26 @@ Database::disconnect();?>
             </div>
           </div>
           <!-- Container-fluid Ends-->
+        </div>
+
+        <div class="modal fade" id="modalEnviarAprobacion" tabindex="-1" role="dialog">
+          <div class="modal-dialog" role="document">
+            <div class="modal-content">
+              <form id="formEnviarAprobacion" method="post" action="enviarAprobacionListaCorte.php?id_lista_corte=<?=$id_lista_corte?>">
+                <div class="modal-header">
+                  <h5 class="modal-title">Confirmar envío a aprobación</h5>
+                  <button type="button" class="close" data-dismiss="modal">&times;</button>
+                </div>
+                <div class="modal-body">
+                  <p>¿Estás seguro de que quieres enviar esta revisión a aprobación?</p>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-light" data-dismiss="modal">Cancelar</button>
+                  <button type="submit" class="btn btn-primary">Confirmar</button>
+                </div>
+              </form>
+            </div>
+          </div>
         </div>
 
         <!-- Modal para eliminas conjuntos -->
@@ -284,6 +305,10 @@ Database::disconnect();?>
     <script src="assets/js/select2/select2-custom.js"></script>
     <script>
       $(document).ready(function () {
+        $('#btnEnviarAprobacion').on('click', function(){
+          $('#modalEnviarAprobacion').modal('show');
+        });
+
         // Setup - add a text input to each footer cell
         $('#dataTables-example667 tfoot th').each( function () {
           var title = $(this).text();


### PR DESCRIPTION
## Summary
- relocate 'Enviar a aprobación' action from nuevaListaCorte.php to nuevaListaCorteConjuntos.php
- include approval modal and handler in conjuntos view

## Testing
- `php -l nuevaListaCorte.php`
- `php -l nuevaListaCorteConjuntos.php`


------
https://chatgpt.com/codex/tasks/task_e_68a45bb5be308321aa47ae85fdf0f8c2