### PR TITLE
Mostrar botón de aprobación solo con conjuntos cargados

### DIFF
--- a/nuevaListaCorteConjuntos.php
+++ b/nuevaListaCorteConjuntos.php
@@ -97,6 +97,11 @@ $data = $q->fetch(PDO::FETCH_ASSOC);
 
 $descripcionProyecto = getDescripcionProyecto($pdo, $data["id_proyecto"]);
 
+$sql = "SELECT COUNT(*) FROM listas_corte_conjuntos WHERE id_lista_corte = ?";
+$q = $pdo->prepare($sql);
+$q->execute([$id_lista_corte]);
+$cantidadConjuntos = (int)$q->fetchColumn();
+
 Database::disconnect();?>
 <!DOCTYPE html>
 <html lang="en">
@@ -211,7 +216,9 @@ Database::disconnect();?>
                         <button type="submit" value="2" name="btn2" id="editConjunto" class="btn btn-success d-none">Modificar</button>
                         <button type="submit" value="3" name="btn3" id="editConjuntoGoPosiciones" class="btn btn-primary d-none">Modificar e ir a Posiciones</button>
                         <button type="button" id="cancelEditConjunto" class="btn btn-light d-none">Cancelar Modificar</button>
+                        <?php if ($cantidadConjuntos > 0) { ?>
                         <button class="btn btn-primary" type="button" id="btnEnviarAprobacion">Enviar a aprobación</button>
+                        <?php } ?>
                         <a href='listarListasCorte.php' id="volverListaCorte" class="btn btn-light">Volver al Listas de corte</a>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- Mostrar el botón Enviar a aprobación únicamente cuando la lista de corte tiene conjuntos

## Testing
- `php -l nuevaListaCorteConjuntos.php`
- `php tests/aprobarComputos.php` *(failed: Failed opening required '../config.php')*
- `php tests/nuevaOrdenTrabajoInvalidQuantity.php`
- `php tests/nuevaOrdenTrabajoRequiresApprovedLC.php`


------
https://chatgpt.com/codex/tasks/task_e_68a461466c0c83219018a897673f3471