### PR TITLE
Fix rounding of total weight display

### DIFF
--- a/nuevaListaCortePosiciones.php
+++ b/nuevaListaCortePosiciones.php
@@ -411,7 +411,7 @@ Database::disconnect();?>
                                 Database::disconnect();?>
                               </tbody>
                             </table>
-							              <b>PESO TOTAL CONJUNTO:&nbsp;<?php echo number_format($pesoTotal,1,",",".");?>&nbsp;kgs</b>
+                                                                      <b>PESO TOTAL CONJUNTO:&nbsp;<?php echo number_format($pesoTotal,2,",",".");?>&nbsp;kgs</b>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- show two decimal places for total weight in cut list positions to avoid rounding up

## Testing
- `php -l nuevaListaCortePosiciones.php`


------
https://chatgpt.com/codex/tasks/task_e_68a46613fb30832184af45072706f51e