### PR TITLE
Display list and revision numbers in Lista de Corte headers

### DIFF
--- a/nuevaListaCorte.php
+++ b/nuevaListaCorte.php
@@ -7,6 +7,8 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }
 require 'database.php';
+$numero = null;
+$nro_revision = null;
 $hoy=date("Y-m-d");
 $modo="create";
 if(isset($_GET["modo"])){
@@ -224,7 +226,7 @@ if (!empty($_POST)) {
     $id_lista_corte = $_GET['id_lista_corte'];
     $formAction="nuevaListaCorte.php?modo=update&id_lista_corte=".$id_lista_corte;
 
-    $sql = "SELECT fecha, id_tarea, id_proyecto, nombre, adjunto FROM listas_corte WHERE id = ?";
+    $sql = "SELECT fecha, id_tarea, id_proyecto, nombre, adjunto, numero, nro_revision FROM listas_corte WHERE id = ?";
     $q = $pdo->prepare($sql);
     $q->execute([$id_lista_corte]);
     $data = $q->fetch(PDO::FETCH_ASSOC);
@@ -234,6 +236,8 @@ if (!empty($_POST)) {
       $id_proyecto=$data["id_proyecto"];
       $nombre=$data["nombre"];
       $adjunto=$data["adjunto"];
+      $numero=$data["numero"];
+      $nro_revision=$data["nro_revision"];
     }
   }
 
@@ -302,7 +306,7 @@ if (!empty($_POST)) {
               <div class="col-sm-12">
                 <div class="card">
                   <div class="card-header">
-                    <h5><?=$ubicacion?></h5>
+                    <h5><?php if($numero !== null && $nro_revision !== null){ echo "Lista de Corte Nº {$numero} - Rev {$nro_revision}"; } else { echo $ubicacion; } ?></h5>
                   </div>
 				          <form class="form theme-form" role="form" method="post" action="<?=$formAction?>" enctype="multipart/form-data">
                     <div class="card-body">

--- a/nuevaListaCorteConjuntos.php
+++ b/nuevaListaCorteConjuntos.php
@@ -90,7 +90,7 @@ if (!empty($_POST)) {
 
 $pdo = Database::connect();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-$sql = "SELECT nombre, numero, id_proyecto FROM listas_corte WHERE id = ? ";
+$sql = "SELECT nombre, numero, nro_revision, id_proyecto FROM listas_corte WHERE id = ? ";
 $q = $pdo->prepare($sql);
 $q->execute([$id_lista_corte]);
 $data = $q->fetch(PDO::FETCH_ASSOC);
@@ -129,7 +129,7 @@ Database::disconnect();?>
               <div class="col-sm-12">
                 <div class="card">
                   <div class="card-header">
-                    <h5>Conjuntos de la Lista de Corte #<?=$data['numero']." - ".$data['nombre'].$descripcionProyecto?>
+                    <h5>Conjuntos de la Lista de Corte Nº <?=$data['numero']?> - Rev <?=$data['nro_revision']?> - <?=$data['nombre'].$descripcionProyecto?>
                       &nbsp;&nbsp;<?php
                       if (!empty(tienePermiso(329))) {?>
                         <img src="img/icon_modificar.png" id="link_modificar_conjunto" style="cursor: pointer;" width="24" height="25" border="0" alt="Modificar" title="Modificar">&nbsp;&nbsp;<?php

--- a/nuevaListaCortePosiciones.php
+++ b/nuevaListaCortePosiciones.php
@@ -323,7 +323,7 @@ if (!empty($_POST)) {
 //$id_lista_corte_conjunto=$_GET['id_lista_corte_conjunto'];
 $pdo = Database::connect();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-$sql = "SELECT lcc.nombre, lcc.id_lista_corte, lc.id_estado_lista_corte, lc.id AS id_lista_corte_revision, lc.id_proyecto, lc.numero FROM listas_corte_conjuntos lcc INNER JOIN listas_corte lc ON lcc.id_lista_corte=lc.id WHERE lcc.id = ? ";
+$sql = "SELECT lcc.nombre, lcc.id_lista_corte, lc.id_estado_lista_corte, lc.id AS id_lista_corte_revision, lc.id_proyecto, lc.numero, lc.nro_revision FROM listas_corte_conjuntos lcc INNER JOIN listas_corte lc ON lcc.id_lista_corte=lc.id WHERE lcc.id = ? ";
 $q = $pdo->prepare($sql);
 $q->execute([$id_lista_corte_conjunto]);
 $data = $q->fetch(PDO::FETCH_ASSOC);
@@ -358,7 +358,7 @@ Database::disconnect();?>
               <div class="col-sm-12">
                 <div class="card">
                   <div class="card-header">
-                    <h5>Posiciones para el Conjunto <?=$data['nombre']?> LC #<?=$data['numero'].$descripcionProyecto?>
+                    <h5>Posiciones para el Conjunto <?=$data['nombre']?> LC Nº <?=$data['numero']?> - Rev <?=$data['nro_revision']?><?=$descripcionProyecto?>
                       &nbsp;&nbsp;<?php
                       /*if (!empty(tienePermiso(331))) {?>
                         <a href="nuevoPosicionListaCorte.php?id_lista_corte_conjunto=<?=$id_lista_corte_conjunto?>"><img src="img/icon_alta.png" width="24" height="25" border="0" alt="Nueva Posicion" title="Nueva Posicion"></a>&nbsp;&nbsp;<?php


### PR DESCRIPTION
## Summary
- Show list number and revision in nuevaListaCorte card header
- Include list and revision numbers in Conjuntos and Posiciones headers

## Testing
- `php -l nuevaListaCorte.php`
- `php -l nuevaListaCorteConjuntos.php`
- `php -l nuevaListaCortePosiciones.php`


------
https://chatgpt.com/codex/tasks/task_e_68a46ccc78b08321827a6513771ce64a