### PR TITLE
Restrict new LC revisions to latest revision

### DIFF
--- a/listarListasCorte.php
+++ b/listarListasCorte.php
@@ -51,6 +51,10 @@ include 'database.php';?>
               <div class="col-sm-12">
                 <?php if(isset($_GET['error']) && $_GET['error']=='lc_no_aprobada'){?>
                 <div class="alert alert-danger">La lista de corte debe estar aprobada para generar una orden de trabajo.</div>
+                <?php } else if(isset($_GET['error']) && $_GET['error']=='lc_revision_mas_reciente'){?>
+                <div class="alert alert-danger">Hay revisiones más recientes generadas para la lista de corte.</div>
+                <?php } else if(isset($_GET['error']) && $_GET['error']=='lc_estado_revision'){?>
+                <div class="alert alert-danger">La lista de corte seleccionada no permite generar una nueva revisión.</div>
                 <?php }?>
               </div>
             </div>
@@ -589,6 +593,23 @@ include 'database.php';?>
       function generarOrdenTrabajoLC(){ window.location.href = this.href; }
       function imprimirListaCorte(){ window.open(this.href, '_blank'); }
       function modificarListaCorte(e){
+        const filaActiva = $("#dataTables-example666 tbody tr.selected");
+        const numeroLc = filaActiva.data("numero-lc");
+        const revision = parseInt(filaActiva.data("nro-revision"),10);
+        let maxRevision = revision;
+        table.rows().every(function(){
+          const tr = $(this.node());
+          if(tr.data("numero-lc") == numeroLc){
+            const rev = parseInt(tr.data("nro-revision"),10);
+            if(rev > maxRevision){
+              maxRevision = rev;
+            }
+          }
+        });
+        if(revision < maxRevision){
+          alert("Hay revisiones más recientes generadas para la lista de corte.");
+          return;
+        }
         const estado = getEstadoListaCorteSeleccionada();
         if(estado && (estado.id === 3 || estado.id === 4)){
           hrefToRedirect = this.href;

--- a/nuevaRevisionListaCorte.php
+++ b/nuevaRevisionListaCorte.php
@@ -26,6 +26,24 @@ if (!empty($_POST)) {
   $q->execute([$id_lista_corte]);
   $data = $q->fetch(PDO::FETCH_ASSOC);
 
+  // Validar que se genera desde la última revisión
+  $sql = "SELECT MAX(nro_revision) AS max_rev FROM listas_corte WHERE numero = ? AND anulado = 0";
+  $q = $pdo->prepare($sql);
+  $q->execute([$data['numero']]);
+  $maxRev = $q->fetchColumn();
+  if ($data['nro_revision'] < $maxRev) {
+    Database::disconnect();
+    header("Location: listarListasCorte.php?error=lc_revision_mas_reciente");
+    exit;
+  }
+
+  // Validar estado que permita revisión
+  if ($data['id_estado_lista_corte'] != 3 && $data['id_estado_lista_corte'] != 4) {
+    Database::disconnect();
+    header("Location: listarListasCorte.php?error=lc_estado_revision");
+    exit;
+  }
+
   // Crear nueva revisión duplicando los datos anteriores
   $nuevoNro = $data['nro_revision'] + 1;
   $motivo = trim($_POST['motivoRevision']);


### PR DESCRIPTION
## Summary
- Validate new revision requests against latest LC revision
- Block revision creation when a more recent revision exists
- Notify when selected LC state does not allow revisions

## Testing
- `php -l listarListasCorte.php`
- `php -l nuevaRevisionListaCorte.php`


------
https://chatgpt.com/codex/tasks/task_e_68a46e7bc3048321bad43e1d03526eaa