### PR TITLE
refactor: reuse existing PDO in notifications

### DIFF
--- a/funciones.php
+++ b/funciones.php
@@ -530,8 +530,7 @@ function marcarComputoGestionandoOTerminado(PDO $pdo, int $idComputo, int $modoD
 
 
 function crearNotificacion(PDO $pdo, int $idTipoNotificacion, int $idEntidad, string $detalleNotificacion, string $asuntoEmail,string $cuerpoEmail): void{
-  // 3) Conexión PDO
-  $pdo = Database::connect();
+  // Se asume que $pdo es una conexión válida y con la configuración adecuada
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
   
   // --- Cargo configuración SMTP desde parámetros ---


### PR DESCRIPTION
## Summary
- stop reinitialising PDO inside `crearNotificacion` and rely on caller's connection

## Testing
- `php -l funciones.php`
- `php nuevaOrdenTrabajoInvalidQuantity.php`
- `php nuevaOrdenTrabajoRequiresApprovedLC.php`
- `php aprobarComputos.php` *(fails: exits without output, requires session/database)*

------
https://chatgpt.com/codex/tasks/task_e_68a478749ebc8321a1071c72d721963b