### PR TITLE
Load APP_ENV from env.php and document configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ composer.lock
 database.php
 # Environment specific configuration
 config.dev.php
+env.php
 .env.development
 #config.php
 save_log.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Grupo NH
 
+## Configuración del entorno
+
+La aplicación utiliza la variable `APP_ENV` para distinguir entre entornos (`production`, `development`, etc.). Define esta variable antes de ejecutar cualquier script, ya sea exportándola o creando un archivo `env.php` en la raíz del proyecto con:
+
+```php
+<?php
+putenv('APP_ENV=development'); // Cambiar según el entorno
+```
+
+`env.php` está ignorado por Git y no debe subirse al repositorio. En servidores de producción se recomienda establecer `APP_ENV=production`.
+
 ## Desarrollo local
 
 Para enviar correos en un entorno local es necesario crear un archivo `config.dev.php` en la raíz del proyecto con las credenciales SMTP de desarrollo. Este archivo está ignorado por Git y no debe commitearse.
@@ -19,6 +30,6 @@ return [
 
 Al montar el entorno local:
 1. Copiar `config.dev.php.example` a `config.dev.php` y completar con las credenciales reales.
-2. Definir la variable de entorno `APP_ENV=development`.
+2. Definir `APP_ENV=development` mediante `env.php` o una variable de entorno.
 
 Cuando `APP_ENV` es `development` y existe `config.dev.php`, la aplicación utilizará estas credenciales en lugar de las almacenadas en base de datos.

--- a/config.php
+++ b/config.php
@@ -1,5 +1,19 @@
 <?php
 
+// Load application environment from env.php or environment variables
+$envFile = __DIR__ . '/env.php';
+if (file_exists($envFile)) {
+    require_once $envFile;
+}
+
+if (!getenv('APP_ENV')) {
+    putenv('APP_ENV=production');
+}
+
+if (!defined('APP_ENV')) {
+    define('APP_ENV', getenv('APP_ENV'));
+}
+
 /*$host = "localhost";
 $username = "root";
 $password = "";


### PR DESCRIPTION
## Summary
- Load APP_ENV from optional env.php file and default to production
- Ignore env.php from version control
- Document how to configure APP_ENV using env.php or environment variables

## Testing
- `php -l config.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4887bcfa0832181c7a33fed886936