### PR TITLE
Abbreviate detail list counts in LC view

### DIFF
--- a/get_detalle_lista_corte.php
+++ b/get_detalle_lista_corte.php
@@ -7,8 +7,30 @@ $id_lc = $_POST['id_lc'];
 $pdo = Database::connect();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-//$sql = " SELECT c.id, c.nombre, c.cantidad, c.peso, e.estado FROM listas_corte_conjuntos c inner join estados_lista_corte_conjuntos e on e.id = c.id_estado_lista_corte_conjuntos WHERE c.id_lista_corte = ".$id_lc;
-$sql = " SELECT lcc.nombre,lcc.cantidad AS cant_conj,lcp.posicion,lcp.cantidad AS cant_pos,m.concepto,GROUP_CONCAT(tp.tipo SEPARATOR ',') AS procesos,elcc.estado as estado FROM listas_corte_conjuntos lcc inner join estados_lista_corte_conjuntos elcc on elcc.id = lcc.id_estado_lista_corte_conjuntos LEFT JOIN lista_corte_posiciones lcp ON lcp.id_lista_corte_conjunto=lcc.id LEFT JOIN lista_corte_procesos lcpr ON lcpr.id_lista_corte_posicion=lcp.id LEFT JOIN materiales m ON lcp.id_material=m.id LEFT JOIN tipos_procesos tp ON lcpr.id_tipo_proceso=tp.id WHERE lcc.id_lista_corte = $id_lc GROUP BY lcp.id";
+$sql = " SELECT \
+            lcc.nombre,\
+            lcc.cantidad AS cant_conj,\
+            lcp.posicion,\
+            m.concepto,\
+            lcp.cantidad AS cant_pos,\
+            (lcc.cantidad * lcp.cantidad) AS cant_total,\
+            IFNULL(otd.cant_liberadas,0) AS cant_liberadas,\
+            IFNULL(otd.cant_proceso,0) AS cant_proceso,\
+            GROUP_CONCAT(tp.tipo SEPARATOR ',') AS procesos,\
+            elcc.estado AS estado\
+          FROM listas_corte_conjuntos lcc\
+          INNER JOIN estados_lista_corte_conjuntos elcc ON elcc.id = lcc.id_estado_lista_corte_conjuntos\
+          LEFT JOIN lista_corte_posiciones lcp ON lcp.id_lista_corte_conjunto = lcc.id\
+          LEFT JOIN materiales m ON lcp.id_material = m.id\
+          LEFT JOIN lista_corte_procesos lcpr ON lcpr.id_lista_corte_posicion = lcp.id\
+          LEFT JOIN tipos_procesos tp ON lcpr.id_tipo_proceso = tp.id\
+          LEFT JOIN (\
+              SELECT id_posicion, SUM(cant_liberadas) AS cant_liberadas, SUM(cant_proceso) AS cant_proceso\
+              FROM ordenes_trabajo_detalle\
+              GROUP BY id_posicion\
+          ) otd ON otd.id_posicion = lcp.id\
+          WHERE lcc.id_lista_corte = $id_lc\
+          GROUP BY lcp.id";
 $aConjuntos=[];
 foreach ($pdo->query($sql) as $row) {
   $aConjuntos[]=[
@@ -23,8 +45,11 @@ foreach ($pdo->query($sql) as $row) {
     2=>$row["posicion"],
     3=>$row["concepto"],
     4=>$row["cant_pos"],
-    5=>$row["procesos"],
-	6=>$row["estado"]
+    5=>$row["cant_total"],
+    6=>$row["cant_liberadas"],
+    7=>$row["cant_proceso"],
+    8=>$row["procesos"],
+    9=>$row["estado"]
   ];
 }
 

--- a/listarListasCorte.php
+++ b/listarListasCorte.php
@@ -233,22 +233,28 @@ include 'database.php';?>
                         <thead>
                           <tr>
                             <th>Conjunto</th>
-                            <th>Cantidad Conjuntos</th>
+                            <th>C. Conj</th>
                             <th>Posicion</th>
                             <th>Concepto</th>
-                            <th>Cantidad Posiciones</th>
+                            <th>C. Pos</th>
+                            <th>C. Tot</th>
+                            <th>C. Lib</th>
+                            <th>C. Proc</th>
                             <th>Procesos</th>
                             <th>Estado</th>
                           </tr>
                         </thead>
                         <tbody></tbody>
-						            <tfoot>
+                                                            <tfoot>
                           <tr>
                             <th>Conjunto</th>
-                            <th>Cantidad Conjuntos</th>
+                            <th>C. Conj</th>
                             <th>Posicion</th>
                             <th>Concepto</th>
-                            <th>Cantidad Posiciones</th>
+                            <th>C. Pos</th>
+                            <th>C. Tot</th>
+                            <th>C. Lib</th>
+                            <th>C. Proc</th>
                             <th>Procesos</th>
                             <th>Estado</th>
                           </tr>


### PR DESCRIPTION
## Summary
- Add total, liberated, and in-process quantities to LC detail query
- Reintroduce processes column while keeping status column in Lista de Corte detail table
- Display quantity columns with abbreviated headers in Lista de Corte detail table

## Testing
- `php -l get_detalle_lista_corte.php`
- `php -l listarListasCorte.php`


------
https://chatgpt.com/codex/tasks/task_e_68a645a43b2c8321ad9c966c3bc24eea