### PR TITLE
Agregar rechazos y reprocesos al detalle de listas de corte

### DIFF
--- a/get_detalle_lista_corte.php
+++ b/get_detalle_lista_corte.php
@@ -14,9 +14,10 @@ $sql = " SELECT
     m.concepto,
     lcp.cantidad AS cant_pos,
     (lcc.cantidad * lcp.cantidad) AS cant_total,
-    IFNULL(otd.cant_liberadas,0) AS cant_liberadas,
-    IFNULL(otd.cant_proceso,0) AS cant_proceso,
-    GROUP_CONCAT(tp.tipo SEPARATOR ',') AS procesos,
+    COALESCE(otd.cant_liberadas,0) AS cant_liberadas,
+    COALESCE(otd.cant_rechazadas,0) AS cant_rechazadas,
+    COALESCE(otd.cant_reproceso,0) AS cant_reproceso,
+    GROUP_CONCAT(DISTINCT tp.tipo SEPARATOR ',') AS procesos,
     elcc.estado AS estado
   FROM listas_corte_conjuntos lcc
   INNER JOIN estados_lista_corte_conjuntos elcc ON elcc.id = lcc.id_estado_lista_corte_conjuntos
@@ -25,7 +26,7 @@ $sql = " SELECT
   LEFT JOIN lista_corte_procesos lcpr ON lcpr.id_lista_corte_posicion = lcp.id
   LEFT JOIN tipos_procesos tp ON lcpr.id_tipo_proceso = tp.id
   LEFT JOIN (
-      SELECT id_posicion, SUM(cant_liberadas) AS cant_liberadas, SUM(cant_proceso) AS cant_proceso
+      SELECT id_posicion, SUM(cant_liberadas) AS cant_liberadas, SUM(cant_rechazadas) AS cant_rechazadas, SUM(cant_proceso) AS cant_reproceso
       FROM ordenes_trabajo_detalle
       GROUP BY id_posicion
   ) otd ON otd.id_posicion = lcp.id
@@ -47,9 +48,10 @@ foreach ($pdo->query($sql) as $row) {
     4=>$row["cant_pos"],
     5=>$row["cant_total"],
     6=>$row["cant_liberadas"],
-    7=>$row["cant_proceso"],
-    8=>$row["procesos"],
-    9=>$row["estado"]
+    7=>$row["cant_rechazadas"],
+    8=>$row["cant_reproceso"],
+    9=>$row["procesos"],
+    10=>$row["estado"]
   ];
 }
 

--- a/listarListasCorte.php
+++ b/listarListasCorte.php
@@ -239,7 +239,8 @@ include 'database.php';?>
                             <th>Cant. Pos</th>
                             <th>Cant. Tot</th>
                             <th>Cant. Lib</th>
-                            <th>Cant. Proc</th>
+                            <th>Cant. Rech</th>
+                            <th>Cant. Reproc</th>
                             <th>Procesos</th>
                             <th>Estado</th>
                           </tr>
@@ -254,7 +255,8 @@ include 'database.php';?>
                             <th>Cant. Pos</th>
                             <th>Cant. Tot</th>
                             <th>Cant. Lib</th>
-                            <th>Cant. Proc</th>
+                            <th>Cant. Rech</th>
+                            <th>Cant. Reproc</th>
                             <th>Procesos</th>
                             <th>Estado</th>
                           </tr>


### PR DESCRIPTION
## Summary
- Registrar cantidades rechazadas y en reproceso por posición al listar una lista de corte
- Mostrar nuevas columnas de rechazos y reprocesos en la tabla de detalle
- Evitar procesos duplicados con `GROUP_CONCAT(DISTINCT ...)`

## Testing
- `php -l get_detalle_lista_corte.php`
- `php -l listarListasCorte.php`
- `php tests/nuevaOrdenTrabajoRequiresApprovedLC.php`
- `php tests/nuevaOrdenTrabajoInvalidQuantity.php`


------
https://chatgpt.com/codex/tasks/task_e_68a654a205f48321a31bc535083c8781