### PR TITLE
Use prepared statements for get_conjuntos

### DIFF
--- a/get_conjuntos.php
+++ b/get_conjuntos.php
@@ -7,9 +7,11 @@ $id_lc = $_POST['id_lc'];
 $pdo = Database::connect();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-$sql = " SELECT c.`id`, c.`nombre`, c.`cantidad`, c.`peso`, e.estado FROM `listas_corte_conjuntos` c inner join estados_lista_corte_conjuntos e on e.id = c.`id_estado_lista_corte_conjuntos` WHERE c.`id_lista_corte` = ".$id_lc;
+$sql = " SELECT c.`id`, c.`nombre`, c.`cantidad`, c.`peso`, e.estado FROM `listas_corte_conjuntos` c inner join estados_lista_corte_conjuntos e on e.id = c.`id_estado_lista_corte_conjuntos` WHERE c.`id_lista_corte` = ?";
+$stmt = $pdo->prepare($sql);
+$stmt->execute([$id_lc]);
 $aConjuntos=[];
-foreach ($pdo->query($sql) as $row) {
+foreach ($stmt as $row) {
 	
   $aConjuntos[]=[
     0 => $row[0],


### PR DESCRIPTION
## Summary
- Secure get_conjuntos SQL query by using a prepared statement with parameter binding

## Testing
- `php -l get_conjuntos.php`


------
https://chatgpt.com/codex/tasks/task_e_68a712066428832184b1099f0026e70e