### PR TITLE
Abbreviate quantity labels and hide conjuntos column in OT detail

### DIFF
--- a/listarOrdenesTrabajo.php
+++ b/listarOrdenesTrabajo.php
@@ -223,9 +223,9 @@ include 'database.php';
                           <tr>
                             <th class="d-none">ID</th>
                             <th>Conjunto</th>
-                            <th>Cantidad Conjuntos</th>
+                            <th class="d-none">Cant. Conjuntos</th>
                             <th>Posicion</th>
-                            <th>Cantidad Pedida</th>
+                            <th>Cant. Pedida</th>
                             <th>Material</th>
                             <th>Procesos</th>
                             <th>Estado</th>
@@ -241,9 +241,9 @@ include 'database.php';
                           <tr>
                             <th class="d-none">ID</th>
                             <th>Conjunto</th>
-                            <th>Cantidad Conjuntos</th>
+                            <th class="d-none">Cant. Conjuntos</th>
                             <th>Posicion</th>
-                            <th>Cantidad Pedida</th>
+                            <th>Cant. Pedida</th>
                             <th>Material</th>
                             <th>Procesos</th>
                             <th>Estado</th>
@@ -636,10 +636,10 @@ include 'database.php';
             $('#tablaDetalleOT').DataTable({
               stateSave: false,
               responsive: false,
-			        "columnDefs": [{
-                "targets": [0],
-                "className": 'd-none'
-              }],
+              "columnDefs": [
+                { "targets": [0], "className": 'd-none', "visible": false },
+                { "targets": [2], "visible": false }
+              ],
               data: data,
               language: {
                 "decimal": "",


### PR DESCRIPTION
## Summary
- Shorten Cantidad labels to Cant. in order detail table
- Hide Cantidad Conjuntos column using DataTables column definitions

## Testing
- `php -l listarOrdenesTrabajo.php`


------
https://chatgpt.com/codex/tasks/task_e_68a71949af2c8321bf52d8d468bb0e28