### PR TITLE
Agregar envío a producción para OT

### DIFF
--- a/enviarProduccionOT.php
+++ b/enviarProduccionOT.php
@@ -1,0 +1,48 @@
+<?php
+require("config.php");
+require_once("funciones.php");
+if (empty($_SESSION['user'])) {
+  header("Location: index.php");
+  die("Redirecting to index.php");
+}
+require 'database.php';
+
+$id = $_GET['id'] ?? null;
+if ($id) {
+  $pdo = Database::connect();
+  $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+  // Cambia estado a En Producción solo si está Pendiente
+  $sql = "UPDATE ordenes_trabajo SET id_estado_orden_trabajo = 3 WHERE id = ? AND id_estado_orden_trabajo = 2";
+  $q = $pdo->prepare($sql);
+  $q->execute([$id]);
+
+  if ($q->rowCount() > 0) {
+    // Registrar log
+    $sqlLog = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (now(), ?, 'Envio a producción OT', 'Orden de Trabajo', 'verOrdenTrabajo.php?id=$id')";
+    $qLog = $pdo->prepare($sqlLog);
+    $qLog->execute([$_SESSION['user']['id']]);
+
+    // Obtener información para el correo/notificación
+    $sqlInfo = "SELECT lc.id_proyecto, ot.nro_orden_trabajo FROM ordenes_trabajo ot INNER JOIN listas_corte lc ON ot.id_lista_corte = lc.id WHERE ot.id = ?";
+    $qInfo = $pdo->prepare($sqlInfo);
+    $qInfo->execute([$id]);
+    $info = $qInfo->fetch(PDO::FETCH_ASSOC);
+
+    if ($info) {
+      $descProyecto = getDescripcionProyecto($pdo, $info['id_proyecto']);
+      $descripcionOT = 'OT '.$info['nro_orden_trabajo'].$descProyecto;
+
+      // Enviar notificación y correo
+      $idTipoNotificacion = 8; // Producción
+      $detalleNotificacion = 'ID OT: #'.$id;
+      $asuntoEmail = 'Módulo Producción - Envío a Producción '.$descripcionOT;
+      $cuerpoEmail = 'La '.$descripcionOT.' ha sido enviada a producción.';
+      crearNotificacion($pdo, $idTipoNotificacion, $id, $detalleNotificacion, $asuntoEmail, $cuerpoEmail);
+    }
+  }
+
+  Database::disconnect();
+}
+
+header("Location: listarOrdenesTrabajo.php");

--- a/listarOrdenesTrabajo.php
+++ b/listarOrdenesTrabajo.php
@@ -97,6 +97,11 @@ include 'database.php';
                       }?>
                       <a href="#" id="link_ver_ot"><img src="img/eye.png" width="24" height="15" border="0" alt="Ver" title="Ver"></a>
                       &nbsp;&nbsp;<?php
+                      if (!empty(tienePermiso(318))) {?>
+                        <a href="#" id="link_enviar_produccion_ot"><img src="img/aprobar.png" width="24" height="25" border="0" alt="Enviar a Producción" title="Enviar a Producción"></a>
+                        &nbsp;&nbsp;<?php
+                      }?>
+                      <?php
                       if (!empty(tienePermiso(317))) {?>
                         <a href="#" id="link_cancelar_ot"><img src="img/icon_baja.png" width="24" height="25" border="0" alt="Eliminar" title="Eliminar"></a>
                         &nbsp;&nbsp;<?php
@@ -426,13 +431,14 @@ include 'database.php';
           var t=$(this).parent();
 
           let id_ot=t.find("td:first-child").html();
-		      let estado = t.find("td:nth-child(10)").html();
+                      let estado = t.find("td:nth-child(10)").html();
           if(t.hasClass('selected')){
             deselectRow(t);
             get_detalle_orden_trabajo(0)
 
             $("#link_modificar_ot").attr("href","#");
             $("#link_ver_ot").attr("href","#");
+            $("#link_enviar_produccion_ot").attr("href","#");
             $("#link_nuevo_consumo").attr("href","#");
             $("#link_cancelar_ot").attr("data-target","#");
           }else{
@@ -446,6 +452,11 @@ include 'database.php';
               $("#link_modificar_ot").attr("href","nuevaOrdenTrabajo.php?id="+id_ot);
             } else {
               $("#link_modificar_ot").attr("href","#");
+            }
+            if ((estado == "Pendiente") || (estado == "Para Aprobar")) {
+              $("#link_enviar_produccion_ot").attr("href","enviarProduccionOT.php?id="+id_ot);
+            } else {
+              $("#link_enviar_produccion_ot").attr("href","#");
             }
             if (estado == "En Producción") {
               $("#link_nuevo_consumo").attr("href","nuevoConsumo.php?id_orden_trabajo="+id_ot);
@@ -485,6 +496,13 @@ include 'database.php';
           let target=this.dataset.target;
           if(target==undefined || target=="#"){
             alert("Por favor seleccione una orden de trabajo para eliminarla")
+          }
+        })
+
+        $("#link_enviar_produccion_ot").on("click",function(){
+          let l=document.location.href;
+          if(this.href==l || this.href==l+"#"){
+            alert("Por favor seleccione una orden de trabajo en estado 'Pendiente' para enviarla a producción")
           }
         })
 


### PR DESCRIPTION
## Summary
- Añadir botón en listado de OT para enviarlas a producción
- Crear script que cambia estado a producción y notifica por email

## Testing
- `php tests/aprobarComputos.php`
- `php tests/nuevaOrdenTrabajoInvalidQuantity.php`
- `php tests/nuevaOrdenTrabajoNoDuplicaPosiciones.php`
- `php tests/nuevaOrdenTrabajoRequiresApprovedLC.php`
- `php tests/aprobarComputos copy.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7314a18008321a4c1075d2681bebb