### PR TITLE
Adjust menu highlighting based on production flag

### DIFF
--- a/menu.php
+++ b/menu.php
@@ -1,7 +1,8 @@
 <?php include("permisos.php");?>
 <?php
 function abrirMenu($op) {
-	$current_page = basename($_SERVER['SCRIPT_NAME']);
+        $current_page = basename($_SERVER['SCRIPT_NAME']);
+        $isProd = isset($_GET['prod']) && $_GET['prod'] == 1;
 	if ($op == "1") {
 		if ($current_page == "dashboard.php") {
 			echo 'class="active"';
@@ -36,24 +37,24 @@ function abrirMenu($op) {
 		($current_page == "listarFacturasCompra.php")) {
 			echo 'class="active"';
 		}
-	} else if ($op == "6") {
-		if (($current_page == "listarIngresos.php") || 
-		($current_page == "listarEgresos.php") || 
-		($current_page == "listarOrdenesTrabajo.php") || 
-		($current_page == "listarConsumos.php") || 
-		($current_page == "listarComputos.php") || 
-		($current_page == "listarColadas.php") ||
-		($current_page == "listarListasCorte.php") || 
-		($current_page == "listarPackingList.php")) {
-			echo 'class="active"';
-		}
-	} else if ($op == "7") {
-		if (($current_page == "listarTareas.php") || 
-		($current_page == "listarComputos.php") || 
-		($current_page == "listarListasCorte.php") || 
-		($current_page == "listarPackingList.php")) {
-			echo 'class="active"';
-		}
+        } else if ($op == "6") {
+                if (($current_page == "listarIngresos.php") ||
+                ($current_page == "listarEgresos.php") ||
+                ($current_page == "listarOrdenesTrabajo.php") ||
+                ($current_page == "listarConsumos.php") ||
+                ($current_page == "listarComputos.php" && $isProd) ||
+                ($current_page == "listarColadas.php") ||
+                ($current_page == "listarListasCorte.php" && $isProd) ||
+                ($current_page == "listarPackingList.php" && $isProd)) {
+                        echo 'class="active"';
+                }
+        } else if ($op == "7") {
+                if (($current_page == "listarTareas.php") ||
+                ($current_page == "listarComputos.php" && !$isProd) ||
+                ($current_page == "listarListasCorte.php" && !$isProd) ||
+                ($current_page == "listarPackingList.php" && !$isProd)) {
+                        echo 'class="active"';
+                }
 	} else if ($op == "8") {
 		if ($current_page == "listarDespachos.php") {
 			echo 'class="active"';


### PR DESCRIPTION
## Summary
- Differentiate Production vs Engineering menu entries based on `prod` query parameter.
- Ensure `listarComputos.php`, `listarListasCorte.php`, and `listarPackingList.php` activate the correct menu.

## Testing
- `php -l menu.php`
- `php -r 'session_start(); $_SESSION["user"]["permisos"]=[]; $_SERVER["SCRIPT_NAME"]="listarListasCorte.php"; $_GET["prod"]=1; ob_start(); include "menu.php"; $out = ob_get_clean(); echo $out;' | rg -n '<li.*Producci|<li.*Ingenier'`
- `php -r 'session_start(); $_SESSION["user"]["permisos"]=[]; $_SERVER["SCRIPT_NAME"]="listarListasCorte.php"; ob_start(); include "menu.php"; echo ob_get_clean();' | rg -n '<li.*Producci|<li.*Ingenier'`


------
https://chatgpt.com/codex/tasks/task_e_68a84d9afc1083219830f1013f3a3c4a