### PR TITLE
Preserve prod filter parameter across list pages

### DIFF
--- a/listarComputos.php
+++ b/listarComputos.php
@@ -5,7 +5,9 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }*/
 include 'config.php';
-include 'database.php';?>
+include 'database.php';
+$prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head><?php
@@ -54,7 +56,7 @@ include 'database.php';?>
               <div class="col-md-12">
                 <div class="card">
                   <div class="card-body">
-                  <form class="form-inline theme-form mt-3" name="form1" method="post" action="listarComputos.php">
+                  <form class="form-inline theme-form mt-3" name="form1" method="post" action="listarComputos.php<?= $prodQuery ?>">
                     <div class="form-group mb-0">
                       N.Sitio/N.Proy:&nbsp;<input class="form-control" size="3" type="text" value="<?php if (isset($_POST['nro'])) echo $_POST['nro'] ?>" name="nro" id="nro">
                     </div>
@@ -83,7 +85,7 @@ include 'database.php';?>
 							        </select>
 					          </div>
                     <div class="form-group mb-0">
-                      <button class="btn btn-primary" onclick="document.form1.target='_self';document.form1.action='listarComputos.php'">Buscar</button>
+                      <button class="btn btn-primary" onclick="document.form1.target='_self';document.form1.action='listarComputos.php<?= $prodQuery ?>'">Buscar</button>
                     </div>
                   </form>
                 </div>

--- a/listarListasCorte.php
+++ b/listarListasCorte.php
@@ -5,7 +5,9 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }*/
 include 'config.php';
-include 'database.php';?>
+include 'database.php';
+$prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
+?>
 <!DOCTYPE html>
 <html lang="en">
   <head><?php
@@ -62,7 +64,7 @@ include 'database.php';?>
               <div class="col-md-12">
                 <div class="card">
                   <div class="card-body">
-                    <form class="form-inline theme-form mt-3" name="form1" method="post" action="listarListasCorte.php">
+                    <form class="form-inline theme-form mt-3" name="form1" method="post" action="listarListasCorte.php<?= $prodQuery ?>">
                       <div class="form-group mb-0">
                         N.Sitio/N.Proy:&nbsp;<input class="form-control" size="3" type="text" value="<?php if (isset($_POST['nro'])) echo $_POST['nro'] ?>" name="nro" id="nro">
                       </div>
@@ -91,7 +93,7 @@ include 'database.php';?>
                         </select>
                       </div>
                       <div class="form-group mb-0">
-                        <button class="btn btn-primary" id="btnFiltrar" onclick="document.form1.target='_self';document.form1.action='listarListasCorte.php'">Buscar</button>
+                        <button class="btn btn-primary" id="btnFiltrar" onclick="document.form1.target='_self';document.form1.action='listarListasCorte.php<?= $prodQuery ?>'">Buscar</button>
                       </div>
                     </form>
                   </div>

--- a/listarPackingList.php
+++ b/listarPackingList.php
@@ -5,6 +5,7 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }
 include 'database.php';
+$prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -54,7 +55,7 @@ include 'database.php';
 			<div class="col-md-12">
 				<div class="card">
 				  <div class="card-body">
-					<form class="form-inline theme-form mt-3" name="form1" method="post" action="listarPackingList.php">
+                                        <form class="form-inline theme-form mt-3" name="form1" method="post" action="listarPackingList.php<?= $prodQuery ?>">
 					  <div class="form-group mb-0">
 						N.Sitio/N.Proy:&nbsp;<input class="form-control" size="3" type="text" value="<?php if (isset($_POST['nro'])) echo $_POST['nro'] ?>" name="nro">
 					  </div>
@@ -85,7 +86,7 @@ include 'database.php';
 							</select>
 					  </div>
 					  <div class="form-group mb-0">
-						<button class="btn btn-primary" onclick="document.form1.target='_self';document.form1.action='listarPackingList.php'">Buscar</button>
+                                                <button class="btn btn-primary" onclick="document.form1.target='_self';document.form1.action='listarPackingList.php<?= $prodQuery ?>'">Buscar</button>
 					  </div>
 					</form>
 				</div>


### PR DESCRIPTION
## Summary
- keep `prod` query parameter when filtering Computos, Listas de Corte, and Packing List tables

## Testing
- `php -l listarComputos.php`
- `php -l listarListasCorte.php`
- `php -l listarPackingList.php`


------
https://chatgpt.com/codex/tasks/task_e_68a86273e984832186103deca66a29d7