### PR TITLE
Propagate prod parameter across lista de corte workflows

### DIFF
--- a/clonarListaCorte.php
+++ b/clonarListaCorte.php
@@ -6,6 +6,9 @@ if (empty($_SESSION['user'])) {
 }
 
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 // funciones.php is included from config.php. Ensure it is available for helper utilities
 
 $id = null;
@@ -14,7 +17,7 @@ if (!empty($_GET['id_lista_corte'])) {
 }
 
 if (null==$id) {
-  header("Location: listarListasCorte.php");
+  header("Location: listarListasCorte.php$prodQuery");
 }
 
 // insert data
@@ -124,7 +127,7 @@ if ($modoDebug==1) {
 } else {
   Database::disconnect();
   //header("Location: nuevaListaCorteConjuntos.php?id_lista_corte=".$id_lista_corte);
-  header("Location: nuevaListaCorte.php?modo=update&id_lista_corte=".$id_lista_corte);
+  header("Location: nuevaListaCorte.php?modo=update&id_lista_corte=".$id_lista_corte.$prodParam);
   exit();
 }
 ?>

--- a/eliminarConjuntoListaCorte.php
+++ b/eliminarConjuntoListaCorte.php
@@ -6,6 +6,9 @@ if (empty($_SESSION['user'])) {
 }
 
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 $id = null;
 if (!empty($_GET['id'])) {
@@ -13,7 +16,7 @@ if (!empty($_GET['id'])) {
 }
 
 if (null==$id) {
-  header("Location: listarListasCorte.php");
+  header("Location: listarListasCorte.php$prodQuery");
 }
 
 $pdo = Database::connect();
@@ -33,5 +36,5 @@ $q = $pdo->prepare($sql);
 $q->execute(array($_SESSION['user']['id']));
 
 Database::disconnect();
-    
-header("Location: nuevaListaCorteConjuntos.php?id_lista_corte=".$data["id_lista_corte"]);
+
+header("Location: nuevaListaCorteConjuntos.php?id_lista_corte=".$data["id_lista_corte"].$prodParam);

--- a/eliminarPosicionListaCorte.php
+++ b/eliminarPosicionListaCorte.php
@@ -6,6 +6,9 @@ if (empty($_SESSION['user'])) {
 }
 
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 $id = null;
 if (!empty($_GET['id'])) {
@@ -13,7 +16,7 @@ if (!empty($_GET['id'])) {
 }
 
 if (null==$id) {
-    header("Location: listarListasCorte.php");
+    header("Location: listarListasCorte.php$prodQuery");
 }
 
 $pdo = Database::connect();
@@ -110,5 +113,5 @@ if ($modoDebug==1) {
   die();
 } else {
   Database::disconnect();
-  header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$idConjunto);
+  header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$idConjunto.$prodParam);
 }

--- a/modificarConjuntoListaCorte.php
+++ b/modificarConjuntoListaCorte.php
@@ -6,6 +6,9 @@
     }
     
     require 'database.php';
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
 
     $id = null;
     if (!empty($_GET['id'])) {
@@ -17,7 +20,7 @@
     
     
     if (null==$id) {
-        header("Location: listarListasCorte.php");
+        header("Location: listarListasCorte.php$prodQuery");
     }
     
     if (!empty($_POST)) {
@@ -49,11 +52,11 @@
             //echo "btn1";
             //echo "modificarListaCorte.php?id=".$_GET["id_lista_corte"]."&revision=".$_GET["revision"];
             //die();
-            header("Location: modificarListaCorte.php?id=".$_GET["id_lista_corte"]."&revision=".$_GET["revision"]);
+            header("Location: modificarListaCorte.php?id=".$_GET["id_lista_corte"]."&revision=".$_GET["revision"].$prodParam);
           }else{
             //echo "btn2";
             //die();
-            header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$_POST['id_conjunto']);
+            header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$_POST['id_conjunto'].$prodParam);
           }
         
         }else{
@@ -68,7 +71,7 @@
 
           Database::disconnect();
         
-          header("Location: listarListasCorte.php");
+          header("Location: listarListasCorte.php$prodQuery");
 
         }
     } else {
@@ -111,7 +114,8 @@
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-				  <form class="form theme-form" role="form" method="post" action="modificarConjuntoListaCorte.php?id=<?php echo $id?>">
+          <form class="form theme-form" role="form" method="post" action="modificarConjuntoListaCorte.php?id=<?php echo $id?><?= $prodParam ?>">
+            <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -156,7 +160,7 @@
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Modificar</button>
-						<a onclick="document.location.href='listarListasCorte.php'" class="btn btn-light">Volver</a>
+                                                <a onclick="document.location.href='listarListasCorte.php<?= $prodQuery ?>'" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/modificarListaCorte.php
+++ b/modificarListaCorte.php
@@ -6,6 +6,9 @@ if (empty($_SESSION['user'])) {
 }
 
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 $id_lista_corte_revision = null;
 if (!empty($_GET['id_lista_corte_revision'])) {
@@ -13,7 +16,7 @@ if (!empty($_GET['id_lista_corte_revision'])) {
 }
 
 if (null==$id_lista_corte_revision) {
-  header("Location: listarListasCorte.php");
+  header("Location: listarListasCorte.php$prodQuery");
 }
 
 if (!empty($_POST)) {
@@ -76,10 +79,10 @@ if (!empty($_POST)) {
       
       //chequear si cambia el estado y llevar al listado de listas de corte o permitir modificar conjuntos
 
-      $redirect="nuevaListaCorteConjuntos.php?id_lista_corte_revision=".$id_lista_corte_revision;
+      $redirect="nuevaListaCorteConjuntos.php?id_lista_corte_revision=".$id_lista_corte_revision.$prodParam;
       //header("Location: nuevaListaCorteConjuntos.php?id_lista_corte_revision=".$id_lista_corte_revision);
     }elseif($_POST['btn1']=="revisar"){
-      $redirect="revisionListasCorte.php?id_lista_corte_revision=".$id_lista_corte_revision;
+      $redirect="revisionListasCorte.php?id_lista_corte_revision=".$id_lista_corte_revision.$prodParam;
       //header("Location: revisionListasCorte.php?id_lista_corte_revision=".$id_lista_corte_revision);
     }
 
@@ -138,7 +141,7 @@ if (!empty($_POST)) {
     $q = $pdo->prepare($sql);
     $q->execute(array($_SESSION['user']['id']));
 
-    $redirect="nuevaListaCorteConjuntos.php?id_lista_corte_revision=".$id_lista_corte_revision;
+    $redirect="nuevaListaCorteConjuntos.php?id_lista_corte_revision=".$id_lista_corte_revision.$prodParam;
   }
 
   if ($modoDebug==1) {
@@ -209,7 +212,8 @@ if (!empty($_POST)) {
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-					        <form class="form theme-form" role="form" method="post" action="modificarListaCorte.php?id_lista_corte_revision=<?=$id_lista_corte_revision?>" enctype="multipart/form-data">
+                                            <form class="form theme-form" role="form" method="post" action="modificarListaCorte.php?id_lista_corte_revision=<?=$id_lista_corte_revision?><?= $prodParam ?>" enctype="multipart/form-data">
+                    <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                     <div class="card-body"><?php
                       if($id_estado_lista_corte!=1){?>
                         <div class="row">
@@ -476,7 +480,7 @@ if (!empty($_POST)) {
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
 					              <button class="btn btn-primary" value="<?=$accion?>" name="btn1" type="submit">Modificar</button>
-                        <a href='listarListasCorte.php' class="btn btn-light">Volver</a>
+                        <a href='listarListasCorte.php<?= $prodQuery ?>' class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>
@@ -493,7 +497,8 @@ if (!empty($_POST)) {
     <div class="modal fade" id="modalConjuntos" tabindex="-1" role="dialog" aria-labelledby="exampleModalConjuntoLabel" aria-hidden="true">
 		  <div class="modal-dialog" role="document">
 		    <div class="modal-content">
-          <form action="modificarConjuntoListaCorte.php?id_lista_corte=<?=$id?>&revision=<?=$_GET['revision']?>" method="POST">
+          <form action="modificarConjuntoListaCorte.php?id_lista_corte=<?=$id?>&revision=<?=$_GET['revision']?><?= $prodParam ?>" method="POST">
+            <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
             <div class="modal-header">
               <h5 class="modal-title" id="exampleModalConjuntoLabel">Modificacion de conjunto</h5>
               <button class="close" type="button" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>

--- a/nuevaListaCorte.php
+++ b/nuevaListaCorte.php
@@ -7,6 +7,9 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 $numero = null;
 $nro_revision = null;
 $hoy=date("Y-m-d");
@@ -36,7 +39,7 @@ if (!empty($_POST)) {
     $params = [$fecha, $id_tarea, $id_proyecto, $nombre, $adjunto, $id_lista_corte];
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
-    $redirect="nuevaListaCorteConjuntos.php?modo=update&id_lista_corte=".$id_lista_corte;
+    $redirect="nuevaListaCorteConjuntos.php?modo=update&id_lista_corte=".$id_lista_corte.$prodParam;
   //}elseif(empty($advertencia)){
   }else{
   
@@ -182,7 +185,7 @@ if (!empty($_POST)) {
       // manejar el error según tu lógica
     }*/
 
-    $redirect="nuevaListaCorteConjuntos.php?id_lista_corte=".$id_lista_corte;
+    $redirect="nuevaListaCorteConjuntos.php?id_lista_corte=".$id_lista_corte.$prodParam;
   }
 
   //if(empty($advertencia)){
@@ -219,12 +222,12 @@ if (!empty($_POST)) {
   $adjunto="";
   $titulo="Nueva";
   $accion="Crear";
-  $formAction="nuevaListaCorte.php";
+  $formAction="nuevaListaCorte.php$prodQuery";
   if($modo == 'update' && isset($_GET['id_lista_corte'])) {
     $titulo="Modificar";
     $accion=$titulo;
     $id_lista_corte = $_GET['id_lista_corte'];
-    $formAction="nuevaListaCorte.php?modo=update&id_lista_corte=".$id_lista_corte;
+    $formAction .= ($prodQuery ? '&' : '?')."modo=update&id_lista_corte=".$id_lista_corte;
 
     $sql = "SELECT fecha, id_tarea, id_proyecto, nombre, adjunto, numero, nro_revision FROM listas_corte WHERE id = ?";
     $q = $pdo->prepare($sql);
@@ -308,7 +311,8 @@ if (!empty($_POST)) {
                   <div class="card-header">
                     <h5><?php if($numero !== null && $nro_revision !== null){ echo $titulo." Lista de Corte Nº {$numero} - Rev {$nro_revision}"; } else { echo $ubicacion; } ?></h5>
                   </div>
-				          <form class="form theme-form" role="form" method="post" action="<?=$formAction?>" enctype="multipart/form-data">
+                                          <form class="form theme-form" role="form" method="post" action="<?=$formAction?>" enctype="multipart/form-data">
+                    <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -393,7 +397,7 @@ if (!empty($_POST)) {
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-success" type="submit"><?=$accion?> y agregar Conjuntos</button>
-                        <a href="listarListasCorte.php" class="btn btn-light">Volver</a>
+                        <a href="listarListasCorte.php<?= $prodQuery ?>" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/nuevaListaCorteConjuntos.php
+++ b/nuevaListaCorteConjuntos.php
@@ -5,6 +5,9 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 if(isset($_GET["id_lista_corte"])){
   $id_lista_corte = filter_input(INPUT_GET, 'id_lista_corte', FILTER_VALIDATE_INT);
@@ -12,7 +15,7 @@ if(isset($_GET["id_lista_corte"])){
   $id_lista_corte = false;
 }
 if (!$id_lista_corte) {
-  header("Location: listarListasCorte.php");
+  header("Location: listarListasCorte.php$prodQuery");
   die("Redirecting to listarListasCorte.php");
 }
 
@@ -31,11 +34,11 @@ if (!empty($_POST)) {
 
     if(isset($_POST['btn2'])){
       $id_lista_corte_conjunto = filter_input(INPUT_POST,'btn2',FILTER_VALIDATE_INT);
-      $redirect="nuevaListaCorteConjuntos.php?id_lista_corte=".$id_lista_corte;
+      $redirect="nuevaListaCorteConjuntos.php?id_lista_corte=".$id_lista_corte.$prodParam;
     }
     if(isset($_POST['btn3'])){
       $id_lista_corte_conjunto = filter_input(INPUT_POST,'btn3',FILTER_VALIDATE_INT);
-      $redirect="nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto;
+      $redirect="nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam;
     }
 	
     $sql = "SELECT count(*) cant FROM `listas_corte_conjuntos` WHERE nombre = ? and id_lista_corte = ? and id <> ? ";
@@ -53,7 +56,7 @@ if (!empty($_POST)) {
 		$q = $pdo->prepare($sql);
 		$q->execute(array($_SESSION['user']['id']));
 	} else {
-		$redirect="nuevaListaCorteConjuntos.php?error=1&id_lista_corte=".$id_lista_corte;
+        $redirect="nuevaListaCorteConjuntos.php?error=1&id_lista_corte=".$id_lista_corte.$prodParam;
 	}
     
 
@@ -77,9 +80,9 @@ if (!empty($_POST)) {
       $q = $pdo->prepare($sql);
       $q->execute(array($_SESSION['user']['id']));
 
-      $redirect="nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto;
+      $redirect="nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam;
     } else {
-      $redirect="nuevaListaCorteConjuntos.php?error=1&id_lista_corte=".$id_lista_corte;
+      $redirect="nuevaListaCorteConjuntos.php?error=1&id_lista_corte=".$id_lista_corte.$prodParam;
     }
   }
 
@@ -143,7 +146,8 @@ Database::disconnect();?>
                       <a href="#" id="link_ver_posicion"><img src="img/eye.png" width="24" height="15" border="0" alt="Ver Posiciones" title="Ver Posiciones"></a>&nbsp;&nbsp;
                     </h5>
                   </div>
-					        <form class="form theme-form" role="form" method="post" action="nuevaListaCorteConjuntos.php?id_lista_corte=<?=$id_lista_corte?>">
+                                                <form class="form theme-form" role="form" method="post" action="nuevaListaCorteConjuntos.php?id_lista_corte=<?=$id_lista_corte?><?= $prodParam ?>">
+                    <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -219,7 +223,7 @@ Database::disconnect();?>
                         <?php if ($cantidadConjuntos > 0) { ?>
                         <button class="btn btn-primary" type="button" id="btnEnviarAprobacion">Enviar a aprobación</button>
                         <?php } ?>
-                        <a href='listarListasCorte.php' id="volverListaCorte" class="btn btn-danger">Guardar y volver al listado</a>
+                        <a href='listarListasCorte.php<?= $prodQuery ?>' id="volverListaCorte" class="btn btn-danger">Guardar y volver al listado</a>
                       </div>
                     </div>
                   </form>
@@ -233,7 +237,8 @@ Database::disconnect();?>
         <div class="modal fade" id="modalEnviarAprobacion" tabindex="-1" role="dialog">
           <div class="modal-dialog" role="document">
             <div class="modal-content">
-              <form id="formEnviarAprobacion" method="post" action="enviarAprobacionListaCorte.php?id_lista_corte=<?=$id_lista_corte?>">
+              <form id="formEnviarAprobacion" method="post" action="enviarAprobacionListaCorte.php?id_lista_corte=<?=$id_lista_corte?><?= $prodParam ?>">
+                <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                 <div class="modal-header">
                   <h5 class="modal-title">Confirmar envío a aprobación</h5>
                   <button type="button" class="close" data-dismiss="modal">&times;</button>
@@ -384,7 +389,7 @@ Database::disconnect();?>
               $(rowNode).removeClass("selected");
             });
             selectRow(t);
-            $("#link_ver_conjunto_lc").attr("href","verConjuntoListaCorte.php?id="+id_conjunto);
+            $("#link_ver_conjunto_lc").attr("href","verConjuntoListaCorte.php?id="+id_conjunto+"<?= $prodParam ?>");
             //$("#link_modificar_conjunto").attr("href","modificarListaCorteConjunto.php?id="+id_conjunto);
             $("#link_modificar_conjunto").on("click",function(){
               let nombre = t.find("td:nth-child(2)").html();
@@ -402,10 +407,10 @@ Database::disconnect();?>
                 $("#volverListaCorte").toggleClass("d-none")
               }
             })
-            $("#link_ver_posicion").attr("href","nuevaListaCortePosiciones.php?modo=update&id_lista_corte_conjunto="+id_conjunto);
+            $("#link_ver_posicion").attr("href","nuevaListaCortePosiciones.php?modo=update&id_lista_corte_conjunto="+id_conjunto+"<?= $prodParam ?>");
             //$("#link_eliminar_conjunto").attr("href","eliminarConjuntoListaCorte.php?id="+id_conjunto);
             $("#link_eliminar_conjunto").data("id",id_conjunto);
-            $("#link_nueva_posicion").attr("href","nuevaListaCortePosiciones.php?id_lista_corte_conjunto="+id_conjunto);
+            $("#link_nueva_posicion").attr("href","nuevaListaCortePosiciones.php?id_lista_corte_conjunto="+id_conjunto+"<?= $prodParam ?>");
           }
         });
     
@@ -416,7 +421,7 @@ Database::disconnect();?>
         if(id_conjunto!="" && id_conjunto>0){
           let modal=$("#eliminarConjunto")
           modal.modal("show")
-          modal.find(".modal-footer a").attr("href","eliminarConjuntoListaCorte.php?id="+id_conjunto)
+          modal.find(".modal-footer a").attr("href","eliminarConjuntoListaCorte.php?id="+id_conjunto+"<?= $prodParam ?>")
         }
       });
 

--- a/nuevaListaCortePosiciones.php
+++ b/nuevaListaCortePosiciones.php
@@ -5,6 +5,9 @@ if (empty($_SESSION['user'])) {
     die("Redirecting to index.php");
 }
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 $id_lista_corte_conjunto = null;
 if (!empty($_GET['id_lista_corte_conjunto'])) {
@@ -12,7 +15,7 @@ if (!empty($_GET['id_lista_corte_conjunto'])) {
 }
 
 if (null==$id_lista_corte_conjunto) {
-  header("Location: listarListasCorte.php");
+  header("Location: listarListasCorte.php$prodQuery");
 }
 
 if (!empty($_POST)) {
@@ -48,13 +51,13 @@ if (!empty($_POST)) {
     if (str_starts_with($conceptoMat, 'Chapa')) {
       if (!is_numeric($ancho) || $ancho <= 0 || !is_numeric($largo) || $largo <= 0) {
         Database::disconnect();
-        header("Location: nuevaListaCortePosiciones.php?error_medidas=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto);
+        header("Location: nuevaListaCortePosiciones.php?error_medidas=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam);
         exit;
       }
     } else {
       if (!is_numeric($largo) || $largo <= 0) {
         Database::disconnect();
-        header("Location: nuevaListaCortePosiciones.php?error_medidas=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto);
+        header("Location: nuevaListaCortePosiciones.php?error_medidas=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam);
         exit;
       }
     }
@@ -108,7 +111,7 @@ if (!empty($_POST)) {
     if (!empty($dataNum)) {
       if ($dataNum['id_material'] != $id_material || $dataNum['ancho'] != $ancho || $dataNum['largo'] != $largo || $dataNum['diametro'] != $diametro) {
         Database::disconnect();
-        header("Location: nuevaListaCortePosiciones.php?error_numero=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto);
+        header("Location: nuevaListaCortePosiciones.php?error_numero=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam);
         exit;
       }
     }
@@ -193,11 +196,11 @@ if (!empty($_POST)) {
       die();
     } else {
       Database::disconnect();
-      header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto);
+      header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam);
       /*if (!empty($_POST['btn2'])) {
-        header("Location: nuevoConjuntoListaCorte.php?id_lista_corte=".$id_lista_corte);
+        header("Location: nuevoConjuntoListaCorte.php?id_lista_corte=".$id_lista_corte.$prodParam);
       } else {
-        header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto);
+        header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam);
       }*/
     }
 
@@ -242,7 +245,7 @@ if (!empty($_POST)) {
     if (!empty($dataNum)) {
       if ($dataNum['id_material'] != $id_material || $dataNum['ancho'] != $ancho || $dataNum['largo'] != $largo || $dataNum['diametro'] != $diametro) {
         Database::disconnect();
-        header("Location: nuevaListaCortePosiciones.php?error_numero=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto);
+        header("Location: nuevaListaCortePosiciones.php?error_numero=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam);
         exit;
       }
     }
@@ -346,13 +349,13 @@ if (!empty($_POST)) {
           $q->execute([$id_lista_corte_conjunto]);
           $data = $q->fetch(PDO::FETCH_ASSOC);
 
-          header("Location: nuevaListaCorteConjuntos.php?modo=update&id_lista_corte=".$data["id_lista_corte"]);
+          header("Location: nuevaListaCorteConjuntos.php?modo=update&id_lista_corte=".$data["id_lista_corte"].$prodParam);
         } else {
-          header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto);
+          header("Location: nuevaListaCortePosiciones.php?id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam);
         }
       }
     } else {
-      header("Location: nuevaListaCortePosiciones.php?error_repetido=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto);
+      header("Location: nuevaListaCortePosiciones.php?error_repetido=1&id_lista_corte_conjunto=".$id_lista_corte_conjunto.$prodParam);
     }
       
     
@@ -416,7 +419,8 @@ Database::disconnect();?>
                       <a href="#" data-toggle="modal" data-target="#modalPosicionesProyecto"><img src="img/eye.png" width="24" height="15" border="0" alt="Ver todas las posiciones" title="Ver todas las posiciones"></a>&nbsp;&nbsp;
                     </h5>
                   </div>
-					        <form class="form theme-form" role="form" method="post" action="nuevaListaCortePosiciones.php?id_lista_corte_conjunto=<?=$id_lista_corte_conjunto?>">
+                                            <form class="form theme-form" role="form" method="post" action="nuevaListaCortePosiciones.php?id_lista_corte_conjunto=<?=$id_lista_corte_conjunto?><?= $prodParam ?>">
+                    <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="form-group col-12">
@@ -579,7 +583,7 @@ Database::disconnect();?>
                         <button type="submit" value="2" name="btn2" class="btn btn-primary addPosicion">Crear y volver a Conjuntos</button>
                         <button type="submit" value="3" name="btn3" id="editPosicion" class="btn btn-primary d-none">Modificar</button>
                         <button type="button" id="cancelEditPosicion" class="btn btn-danger d-none">Cancelar Modificar</button>
-                        <a href='nuevaListaCorteConjuntos.php?modo=update&id_lista_corte=<?=$data["id_lista_corte"]?>' class="btn btn-danger">Guardar y volver a Conjuntos</a>
+                        <a href='nuevaListaCorteConjuntos.php?modo=update&id_lista_corte=<?=$data["id_lista_corte"]?><?= $prodParam ?>' class="btn btn-danger">Guardar y volver a Conjuntos</a>
                       </div>
                     </div>
                   </form>

--- a/verConjuntoListaCorte.php
+++ b/verConjuntoListaCorte.php
@@ -6,6 +6,9 @@ if (empty($_SESSION['user'])) {
 }
 
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 $id = null;
 if (!empty($_GET['id'])) {
@@ -13,7 +16,7 @@ if (!empty($_GET['id'])) {
 }
 
 if (null==$id) {
-  header("Location: listarListasCorte.php");
+  header("Location: listarListasCorte.php$prodQuery");
 }
 
 if (!empty($_POST)) {
@@ -58,7 +61,8 @@ if (!empty($_POST)) {
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-					        <form class="form theme-form" role="form" method="post" action="">
+                                                <form class="form theme-form" role="form" method="post" action="">
+                    <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -100,7 +104,7 @@ if (!empty($_POST)) {
                     </div>
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
-                        <a href='nuevaListaCorteConjuntos.php?id_lista_corte_revision=<?=$id_lista_corte?>' class="btn btn-light">Volver</a>
+                        <a href='nuevaListaCorteConjuntos.php?id_lista_corte_revision=<?=$id_lista_corte?><?= $prodParam ?>' class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>


### PR DESCRIPTION
## Summary
- Preserve `prod` query parameter when creating listados de corte and their conjunts/posiciones
- Add hidden `prod` inputs and update links and redirects across related pages
- Ensure ancillary actions like cloning or deleting also retain the `prod` context

## Testing
- `php -l nuevaListaCorte.php`
- `php -l nuevaListaCorteConjuntos.php`
- `php -l nuevaListaCortePosiciones.php`
- `php -l eliminarConjuntoListaCorte.php`
- `php -l eliminarPosicionListaCorte.php`
- `php -l verConjuntoListaCorte.php`
- `php -l clonarListaCorte.php`
- `php -l modificarListaCorte.php`
- `php -l modificarConjuntoListaCorte.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8638b39fc83219a544a8d9090d431