### PR TITLE
Propagar parámetro prod en cómputos

### DIFF
--- a/aprobarComputo.php
+++ b/aprobarComputo.php
@@ -6,6 +6,9 @@
     }
     
     require 'database.php';
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
 
     $id = null;
     if (!empty($_GET['id'])) {
@@ -13,7 +16,7 @@
     }
     
     if (null==$id) {
-        header("Location: listarComputos.php");
+        header("Location: listarComputos.php$prodQuery");
     }
     
     $pdo = Database::connect();
@@ -50,11 +53,11 @@
 		$q->execute([$id]);		
 	}
     
-	$sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Aprobación de cómputo','Cómputos','verComputo.php?id=$id')";
+        $sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Aprobación de cómputo','Cómputos','verComputo.php?id=$id$prodParam')";
 	$q = $pdo->prepare($sql);
 	$q->execute(array($_SESSION['user']['id']));
 
 
     Database::disconnect();
         
-    header("Location: listarComputos.php");
+    header("Location: listarComputos.php$prodQuery");

--- a/aprobarComputoDetalle.php
+++ b/aprobarComputoDetalle.php
@@ -46,6 +46,8 @@ Database::disconnect();*/
 
 require("config.php");
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodParam = $prod ? '&prod=' . $prod : '';
 //require 'funciones.php';
 
 // Siempre devolvemos JSON
@@ -132,7 +134,7 @@ try {
     }
 
     // 3) Insertar log
-    $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (NOW(), ?, 'Aprobación de detalle de cómputo', 'Cómputos', 'verComputo.php?id={$idComputo}')";
+    $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (NOW(), ?, 'Aprobación de detalle de cómputo', 'Cómputos', 'verComputo.php?id={$idComputo}$prodParam')";
     $q = $pdo->prepare($sql);
     $q->execute([ $_SESSION['user']['id'] ]);
 

--- a/cancelarComputoDetalle.php
+++ b/cancelarComputoDetalle.php
@@ -1,6 +1,8 @@
 <?php
 require("config.php");
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 // Siempre devolvemos JSON
 header('Content-Type: application/json; charset=utf-8');
@@ -80,7 +82,7 @@ try {
     }
 
     // 3) Insertar log
-    $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (NOW(), ?, 'Cancelación de detalle de cómputo', 'Cómputos', 'verComputo.php?id={$idComputo}')";
+    $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (NOW(), ?, 'Cancelación de detalle de cómputo', 'Cómputos', 'verComputo.php?id={$idComputo}$prodParam')";
     $q = $pdo->prepare($sql);
     $q->execute([ $_SESSION['user']['id'] ]);
 

--- a/eliminarComputo.php
+++ b/eliminarComputo.php
@@ -6,6 +6,9 @@
     }
     
     require 'database.php';
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
 
     $id = null;
     if (!empty($_GET['id'])) {
@@ -13,7 +16,7 @@
     }
     
     if (null==$id) {
-        header("Location: listarComputos.php");
+        header("Location: listarComputos.php$prodQuery");
     }
     
     $pdo = Database::connect();
@@ -33,4 +36,4 @@
 
     Database::disconnect();
         
-    header("Location: listarComputos.php");
+    header("Location: listarComputos.php$prodQuery");

--- a/eliminarItemComputo.php
+++ b/eliminarItemComputo.php
@@ -6,6 +6,9 @@ require("config.php");
 }*/
 
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 $id = null;
 if (!empty($_GET['id'])) {
@@ -13,7 +16,7 @@ if (!empty($_GET['id'])) {
 }
 
 if (null==$id) {
-  header("Location: listarComputos.php");
+  header("Location: listarComputos.php$prodQuery");
 }
 
 $pdo = Database::connect();
@@ -26,4 +29,4 @@ $q->execute(array($id));
     
 Database::disconnect();
     
-header("Location: itemsComputo.php?id=".$_GET['idComputo']."&modo=update&revision=".$_GET['revision']);
+header("Location: itemsComputo.php?id=".$_GET['idComputo']."&modo=update&revision=".$_GET['revision'].$prodParam);

--- a/itemsComputo.php
+++ b/itemsComputo.php
@@ -1,6 +1,9 @@
 <?php
 require("config.php");
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 /*require_once("PHPMailer/class.phpmailer.php");
 require_once("PHPMailer/class.smtp.php");*/
 
@@ -17,7 +20,7 @@ $idOrigen  = $_REQUEST['id']        ?? null;         // id del cómputo original
 $nroRev    = $_REQUEST['revision']  ?? 0;            // número de revisión actual
 
 if (!$idOrigen) {
-  header("Location: listarComputos.php");
+  header("Location: listarComputos.php$prodQuery");
   exit;
 }
 
@@ -118,7 +121,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }*/
 
     // 4) Redirijo al listado
-    header("Location: listarComputos.php");
+    header("Location: listarComputos.php$prodQuery");
     exit;
   }
 
@@ -194,7 +197,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $stmt = $pdo->prepare("SELECT COUNT(*) FROM computos_detalle WHERE cancelado = 0 AND id_computo = ? AND id_material = ?");
     $stmt->execute([$id, $_POST['id_material']]);
     if ($stmt->fetchColumn() > 0) {
-      header("Location: itemsComputo.php?modo=$modo&id=$id&revision=$nroRev&error=1");
+      header("Location: itemsComputo.php?modo=$modo&id=$id&revision=$nroRev&error=1$prodParam");
       exit;
     }
 
@@ -206,17 +209,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Logueo la acción
     $stmt = $pdo->prepare("INSERT INTO logs (fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (NOW(), ?, 'Se ha modificado un item de un cómputo', 'Cómputos', ?)");
-    $link = "verComputo.php?id=$id";
+    $link = "verComputo.php?id=$id$prodParam";
     $stmt->execute([$userId, $link]);
   }
 
   // 6) Redirección final
   if (isset($_POST['btn2'])) {
     // Solo "Enviar a aprobación" (cambia de nombre en el HTML)
-    header("Location: listarComputos.php");
+    header("Location: listarComputos.php$prodQuery");
   } else {
     // "Crear y agregar otro"
-    header("Location: itemsComputo.php?modo=$modo&id=$id&revision=$nroRev");
+    header("Location: itemsComputo.php?modo=$modo&id=$id&revision=$nroRev$prodParam");
   }
   exit;
 }
@@ -309,11 +312,12 @@ Database::disconnect();
                   <div class="card-header">
                     <h5><?=$ubicacion." N° ".$data["nro_computo"]." Rev. N° ".$data["nro_revision"]." (".$data["sitio"]."_".$data["subsitio"]."_".$data["nro_proyecto"].")"?></h5>
                   </div>
-				          <form class="form theme-form" role="form" method="post" id="miFormulario" action="itemsComputo.php?modo=<?=$_GET['modo']?>&id=<?=$id?>">
+                                          <form class="form theme-form" role="form" method="post" id="miFormulario" action="itemsComputo.php?modo=<?=$_GET['modo']?>&id=<?=$id?><?= $prodParam ?>">
                     <!-- Hidden inputs para los parámetros -->
                     <input type="hidden" name="modo"      value="<?= htmlspecialchars($modo) ?>">
                     <input type="hidden" name="id"        value="<?= htmlspecialchars($id) ?>">
                     <input type="hidden" name="revision"  value="<?= htmlspecialchars($revision) ?>">
+                    <input type="hidden" name="prod"      value="<?= $_REQUEST['prod'] ?? '' ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -469,12 +473,12 @@ Database::disconnect();
                          if($b==1){?>
                           <button class="btn btn-primary" type="button" id="btnEnviarAprobacion">Enviar a aprobación</button><?php
                          }?>
-						            <!-- <a href="listarComputos.php" class="btn btn-danger">Guardar y volver al Listado</a> -->
+                                                            <!-- <a href="listarComputos.php<?= $prodQuery ?>" class="btn btn-danger">Guardar y volver al Listado</a> -->
                          <button class="btn btn-danger" type="button" id="guardarYVolver">Guardar y volver al Listado</button>
 
                         <!-- <button type="submit" name="btn1" class="btn btn-success">Crear y Agregar Otro</button>
                         <button type="submit" name="btn2" class="btn btn-primary">Enviar a aprobación</button>
-                        <a href="listarComputos.php" class="btn btn-danger">Volver al Listado</a> -->
+                        <a href="listarComputos.php<?= $prodQuery ?>" class="btn btn-danger">Volver al Listado</a> -->
 
                       </div>
                     </div>
@@ -494,11 +498,12 @@ Database::disconnect();
     <div class="modal fade" id="modalEnviarAprobacion" tabindex="-1" role="dialog">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
-          <form id="formEnviarAprobacion" method="post" action="itemsComputo.php">
+          <form id="formEnviarAprobacion" method="post" action="itemsComputo.php<?= $prodQuery ?>">
             <!-- mantenemos ocultos los campos esenciales -->
             <input type="hidden" name="modo"      value="<?= htmlspecialchars($modo) ?>">
             <input type="hidden" name="id"        value="<?= htmlspecialchars($id) ?>">
             <input type="hidden" name="revision"  value="<?= htmlspecialchars($revision) ?>">
+            <input type="hidden" name="prod"      value="<?= $_REQUEST['prod'] ?? '' ?>">
             <input type="hidden" name="btn2_confirm" value="1">
             <div class="modal-header">
               <h5 class="modal-title">Confirmar envío a aprobación</h5>
@@ -582,6 +587,9 @@ Database::disconnect();
 	
     <!-- Plugins JS Ends-->
     <script>
+      const prod = <?= $prod ?? 0 ?>;
+      const prodQuery = prod ? '?prod=' + prod : '';
+      const prodParam = prod ? '&prod=' + prod : '';
       $(document).ready(function() {
 
         // dentro de tu $(document).ready(...)
@@ -607,7 +615,7 @@ Database::disconnect();
 
           if(id_material=="" && cantidad=="" && fecha_necesidad==""){
             // Redirige a la página de listado
-            window.location.href = "listarComputos.php";
+            window.location.href = "listarComputos.php"+prodQuery;
             return false;
           }
 

--- a/listarComputos.php
+++ b/listarComputos.php
@@ -495,6 +495,8 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
     <!-- Theme js-->
     <script src="assets/js/script.js"></script>
     <script>
+      const prod = <?= isset($_GET['prod']) ? (int)$_GET['prod'] : 0 ?>;
+      const prodParam = prod ? '&prod=' + prod : '';
       $(document).ready(function() {
         // Setup - add a text input to each footer cell
         $('#dataTables-example666 tfoot th').each( function () {
@@ -724,13 +726,13 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
             });
             selectRow(t);
             get_conceptos(id_computo)
-            $("#link_ver_computo").attr("href","verComputo.php?id="+id_computo);
+            $("#link_ver_computo").attr("href","verComputo.php?id="+id_computo+prodParam);
             $("#link_imprimir_computo").attr("target","_blank");
-            $("#link_imprimir_computo").attr("href","imprimirComputo.php?id="+id_computo);
+            $("#link_imprimir_computo").attr("href","imprimirComputo.php?id="+id_computo+prodParam);
             if ((estado == 'Para Aprobar') || (estado == 'Elaboración')) {
-              $("#link_items_computo").attr("href","itemsComputo.php?id="+id_computo+"&modo=nuevo&revision="+nro_revision);
+              $("#link_items_computo").attr("href","itemsComputo.php?id="+id_computo+"&modo=nuevo&revision="+nro_revision+prodParam);
             } else {
-              $("#link_items_computo").attr("href","itemsComputo.php?id="+id_computo+"&modo=update&revision="+nro_revision);  
+              $("#link_items_computo").attr("href","itemsComputo.php?id="+id_computo+"&modo=update&revision="+nro_revision+prodParam);
             }
             if (estado == 'Para Aprobar') {
               $("#link_aprobar_computo").attr("data-toggle","modal");

--- a/modificarComputo.php
+++ b/modificarComputo.php
@@ -5,6 +5,9 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 $id = null;
 if (!empty($_GET['id'])) {
@@ -12,7 +15,7 @@ if (!empty($_GET['id'])) {
 }
 
 if (null==$id) {
-  header("Location: listarComputos.php");
+  header("Location: listarComputos.php$prodQuery");
 }
 
 if (!empty($_POST)) {
@@ -34,7 +37,7 @@ if (!empty($_POST)) {
   $q = $pdo->prepare($sql);
   $q->execute([$_POST['id_cuenta_solicitante'],$_GET['id']]);
 
-  $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Modificación de computo','Computos','verComputo.php?id=$id')";
+  $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Modificación de computo','Computos','verComputo.php?id=$id$prodParam')";
   $q = $pdo->prepare($sql);
   $q->execute(array($_SESSION['user']['id']));
 
@@ -76,7 +79,7 @@ if (!empty($_POST)) {
     }
 
     // 2) INSERT log
-    $link = "verComputo.php?id={$id}";
+    $link = "verComputo.php?id={$id}$prodParam";
     $sql  = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (NOW(), ?, 'Modificación de computo', 'Computos', ?)";
     $q = $pdo->prepare($sql);
     $ok = $q->execute([$_SESSION['user']['id'],$link]);
@@ -158,7 +161,7 @@ if (!empty($_POST)) {
         $sqlLogR = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (NOW(), ?, 'Nueva reserva de stock', 'Computos', ?)";
         $stmtLogR = $pdo->prepare($sqlLogR);
 
-        $params = [$userId, "verComputo.php?id={$idComputo}"];
+        $params = [$userId, "verComputo.php?id={$idComputo}$prodParam"];
 
         if ($modoDebug == 1) {
           // Generar y mostrar la consulta “real”
@@ -295,7 +298,7 @@ if (!empty($_POST)) {
   }
 
   
-  header("Location: verComputo.php?id=".$_GET['id']);
+  header("Location: verComputo.php?id=".$_GET['id'].$prodParam);
 } else {
-  header("Location: listarComputos.php");
+  header("Location: listarComputos.php$prodQuery");
 }

--- a/modificarItemComputo.php
+++ b/modificarItemComputo.php
@@ -5,6 +5,9 @@ require("config.php");
     die("Redirecting to index.php");
 }*/
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 
 $id = null;
 if (!empty($_GET['id'])) {
@@ -12,7 +15,7 @@ if (!empty($_GET['id'])) {
 }
 
 if (null==$id) {
-    header("Location: listarComputos.php");
+    header("Location: listarComputos.php$prodQuery");
 }
 
 if (!empty($_POST)) {
@@ -56,13 +59,13 @@ if (!empty($_POST)) {
     
   }
 
-  $sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Se ha modificado un item de un cómputo','Cómputos','verComputo.php?id=$id')";
+  $sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Se ha modificado un item de un cómputo','Cómputos','verComputo.php?id=$id$prodParam')";
   $q = $pdo->prepare($sql);
   $q->execute(array($_SESSION['user']['id']));
   */
   Database::disconnect();
   
-  header("Location: itemsComputo.php?id=".$_GET['idRetorno']."&modo=".$_GET['modo']."&revision=".$nro_revision);
+  header("Location: itemsComputo.php?id=".$_GET['idRetorno']."&modo=".$_GET['modo']."&revision=".$nro_revision.$prodParam);
 } else {
     $pdo = Database::connect();
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -101,7 +104,7 @@ if (!empty($_POST)) {
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-				  <form class="form theme-form" role="form" method="post" action="modificarItemComputo.php?id=<?php echo $id?>&idRetorno=<?php echo $_GET['idRetorno']?>&modo=<?php echo $_GET['modo']?>&revision=<?php echo $_GET['revision']?>">
+                                  <form class="form theme-form" role="form" method="post" action="modificarItemComputo.php?id=<?php echo $id?>&idRetorno=<?php echo $_GET['idRetorno']?>&modo=<?php echo $_GET['modo']?>&revision=<?php echo $_GET['revision']?><?= $prodParam ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -140,8 +143,9 @@ if (!empty($_POST)) {
 							<div class="form-group row">
 							<label class="col-sm-3 col-form-label">Comentarios</label>
 							<div class="col-sm-9"><textarea name="comentarios" class="form-control"><?php echo $data['comentarios'];?></textarea></div>
-							<input type="hidden" name="nro_revision" value="<?php if (!empty($_GET['revision'])) { echo $_GET['revision']; }else { echo "0"; } ?>">
-							<input type="hidden" name="modo" value="<?php echo $_GET['modo']; ?>">
+                                                        <input type="hidden" name="nro_revision" value="<?php if (!empty($_GET['revision'])) { echo $_GET['revision']; }else { echo "0"; } ?>">
+                                                        <input type="hidden" name="modo" value="<?php echo $_GET['modo']; ?>">
+                                                        <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
 						  </div>
 						</div>
                       </div>
@@ -149,7 +153,7 @@ if (!empty($_POST)) {
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Modificar</button>
-						<a onclick="document.location.href='listarComputos.php'" class="btn btn-light">Volver</a>
+                                            <a href="listarComputos.php<?= $prodQuery ?>" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/nuevaRevisionComputo.php
+++ b/nuevaRevisionComputo.php
@@ -6,6 +6,9 @@
     }
     
     require 'database.php';
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
 
     $id = null;
     if (!empty($_GET['id'])) {
@@ -13,7 +16,7 @@
     }
     
     if (null==$id) {
-        header("Location: listarComputos.php");
+        header("Location: listarComputos.php$prodQuery");
     }
     
     if (!empty($_POST)) {
@@ -30,14 +33,14 @@
 		$q = $pdo->prepare($sql);
 		$q->execute([$_GET['id'],$_POST['nro_revision']+1,$_POST['comentarios']]);
 		
-		$sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Nueva revisión de cómputo','Cómputos','verComputo.php?id=$id')";
+                $sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Nueva revisión de cómputo','Cómputos','verComputo.php?id=$id$prodParam')";
 		$q = $pdo->prepare($sql);
 		$q->execute(array($_SESSION['user']['id']));
 
         
         Database::disconnect();
         
-        header("Location: listarComputos.php");
+        header("Location: listarComputos.php$prodQuery");
     } else {
         $pdo = Database::connect();
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -78,14 +81,15 @@
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-				  <form class="form theme-form" role="form" method="post" action="nuevaRevisionComputo.php?id=<?php echo $id?>">
+                                  <form class="form theme-form" role="form" method="post" action="nuevaRevisionComputo.php?id=<?php echo $id?><?= $prodParam ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
 						  <div class="form-group row">
 							<label class="col-sm-3 col-form-label">Comentarios</label>
 							<div class="col-sm-9"><textarea name="comentarios" class="form-control" required="required" autofocus></textarea></div>
-							<input type="hidden" name="nro_revision" value="<?php echo $_GET['revision'];?>">
+                                                        <input type="hidden" name="nro_revision" value="<?php echo $_GET['revision'];?>">
+                                                        <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
 						  </div>
                         </div>
                       </div>
@@ -93,7 +97,7 @@
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Agregar Revisión</button>
-						<a onclick="document.location.href='listarComputos.php'" class="btn btn-light">Volver</a>
+                                            <a href="listarComputos.php<?= $prodQuery ?>" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/nuevoComputo.php
+++ b/nuevoComputo.php
@@ -7,6 +7,9 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 if (!empty($_POST)) {
   // var_dump($_POST);
   // die;
@@ -60,7 +63,7 @@ if (!empty($_POST)) {
   $q = $pdo->prepare($sql);
   $q->execute([$id_computo,$id_computo]);*/
 
-  $sql = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Nuevo Cómputo','Cómputos','verComputo.php?id=$id_computo')";
+  $sql = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Nuevo Cómputo','Cómputos','verComputo.php?id=$id_computo$prodParam')";
   $q = $pdo->prepare($sql);
   $q->execute(array($_SESSION['user']['id']));
 
@@ -121,7 +124,7 @@ if (!empty($_POST)) {
   }*/
   
   Database::disconnect();
-  header("Location: itemsComputo.php?id=".$id."&revision=0&modo=nuevo");
+  header("Location: itemsComputo.php?id=".$id_computo."&revision=0&modo=nuevo".$prodParam);
 } else {
   $pdo = Database::connect();
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -219,10 +222,11 @@ if (!empty($_POST)) {
                                   }
                                 }
                                 Database::disconnect();?>
-							                </select>
-							                <input type="hidden" name="id_tarea" value="<?php echo $_GET['id'];?>">
-							              </div>
-							            </div>
+                                                                        </select>
+                                                                        <input type="hidden" name="id_tarea" value="<?php echo $_GET['id'];?>">
+                                                                        <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
+                                                                      </div>
+                                                                    </div>
                           <!--<div class="form-group row">
                             <label class="col-sm-3 col-form-label">Revisó(*)</label>
                             <div class="col-sm-9">
@@ -283,7 +287,7 @@ if (!empty($_POST)) {
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Crear</button>
-                        <a href="listarComputos.php" class="btn btn-light">Volver</a>
+                        <a href="listarComputos.php<?= $prodQuery ?>" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>


### PR DESCRIPTION
## Summary
- Añade manejo de parámetro `prod` en creación y edición de cómputos
- Propaga `prod` en listados y enlaces de cómputos
- Ajusta formularios y redirecciones para conservar `prod` en acciones sobre cómputos

## Testing
- `php -l nuevoComputo.php`
- `php -l itemsComputo.php`
- `php -l listarComputos.php`
- `php -l modificarComputo.php`
- `php -l aprobarComputo.php`
- `php -l modificarItemComputo.php`
- `php -l eliminarComputo.php`
- `php -l eliminarItemComputo.php`
- `php -l nuevaRevisionComputo.php`
- `php -l aprobarComputoDetalle.php`
- `php -l cancelarComputoDetalle.php`
- `php -l tests/aprobarComputos.php`


------
https://chatgpt.com/codex/tasks/task_e_68a866855cec8321b2c7cd4240021210