### PR TITLE
Propagate prod parameter in packing list workflow

### DIFF
--- a/eliminarComponentePackingList.php
+++ b/eliminarComponentePackingList.php
@@ -6,13 +6,17 @@ if (empty($_SESSION['user'])) {
 }
 require 'database.php';
 
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
+
 $id = null;
 if (!empty($_GET['id'])) {
   $id = $_REQUEST['id'];
 }
 
 if (null==$id) {
-  header("Location: listarPackingList.php");
+  header("Location: listarPackingList.php$prodQuery");
 }
 
 $pdo = Database::connect();
@@ -35,4 +39,4 @@ $q->execute(array($_SESSION['user']['id']));
 Database::disconnect();
   
 //header("Location: listarPackingList.php");
-header("Location: nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion);
+header("Location: nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion.$prodParam);

--- a/eliminarSeccionPackingList.php
+++ b/eliminarSeccionPackingList.php
@@ -7,13 +7,17 @@ if (empty($_SESSION['user'])) {
 
 require 'database.php';
 
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
+
 $id = null;
 if (!empty($_GET['id'])) {
   $id = $_REQUEST['id'];
 }
 
 if (null==$id) {
-  header("Location: listarPackingList.php");
+  header("Location: listarPackingList.php$prodQuery");
 }
 
 $pdo = Database::connect();
@@ -35,4 +39,4 @@ $q->execute(array($_SESSION['user']['id']));
 Database::disconnect();
   
 //header("Location: listarPackingList.php");
-header("Location: nuevaPackingListSecciones.php?id_packing_list_revision=".$data["id_packing_list_revision"]);
+header("Location: nuevaPackingListSecciones.php?id_packing_list_revision=".$data["id_packing_list_revision"].$prodParam);

--- a/imprimirPackingList.php
+++ b/imprimirPackingList.php
@@ -7,13 +7,17 @@ if (empty($_SESSION['user'])) {
 
 require 'database.php';
 
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
+
 $id = null;
 if (!empty($_GET['id'])) {
   $id = $_REQUEST['id'];
 }
 
 if (null==$id) {
-  header("Location: listarPackingList.php");
+  header("Location: listarPackingList.php$prodQuery");
 }
 
 if (!empty($_POST)) {

--- a/listarPackingList.php
+++ b/listarPackingList.php
@@ -5,7 +5,9 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }
 include 'database.php';
-$prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -182,7 +184,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
                                       </div>
                                       <div class="modal-body">¿Está seguro que desea cancelar el Packing List?</div>
                                       <div class="modal-footer">
-                                        <a href="eliminarPackingList.php?id=<?=$row[5]?>" class="btn btn-primary">Eliminar</a>
+                                        <a href="eliminarPackingList.php?id=<?=$row[5]?><?= $prodParam ?>" class="btn btn-primary">Eliminar</a>
                                         <button class="btn btn-light" type="button" data-dismiss="modal" aria-label="Close">Volver</button>
                                       </div>
                                     </div>
@@ -413,7 +415,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
 			  </div>
 			  <div class="modal-body">¿Está seguro que desea eliminar el Componente?</div>
 			  <div class="modal-footer">
-			  <a href="eliminarComponentePackingList.php?id=<?php echo $row[0]; ?>" class="btn btn-primary">Eliminar</a>
+                          <a href="eliminarComponentePackingList.php?id=<?php echo $row[0]; ?><?= $prodParam ?>" class="btn btn-primary">Eliminar</a>
 			  <button class="btn btn-light" type="button" data-dismiss="modal" aria-label="Close">Volver</button>
 			  </div>
 			</div>
@@ -442,7 +444,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
 				  </div>
 				  <div class="modal-body">¿Está seguro que desea eliminar la Sección?</div>
 				  <div class="modal-footer">
-				  <a href="eliminarSeccionPackingList.php?id=<?php echo $row[0]; ?>" class="btn btn-primary">Eliminar</a>
+                                  <a href="eliminarSeccionPackingList.php?id=<?php echo $row[0]; ?><?= $prodParam ?>" class="btn btn-primary">Eliminar</a>
 				  <button class="btn btn-light" type="button" data-dismiss="modal" aria-label="Close">Volver</button>
 				  </div>
 				</div>
@@ -508,7 +510,10 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
     <!-- Plugins JS Ends-->
     <!-- Theme js-->
     <script src="assets/js/script.js"></script>
-  <script>
+    <script>
+    const prod = <?= $prod ?? 0 ?>;
+    const prodQuery = prod ? '?prod=' + prod : '';
+    const prodParam = prod ? '&prod=' + prod : '';
     $(document).ready(function() {
     // Setup - add a text input to each footer cell
     $('#dataTables-example666 tfoot th').each( function () {
@@ -643,11 +648,11 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
           });
           selectRow(t);
 		      get_secciones(id_pl_revision)
-          $("#link_ver_pl").attr("href","verPackingList.php?id="+id_pl_revision);
-		  $("#link_imprimir_pl_con").attr("target","_blank");
-          $("#link_imprimir_pl_con").attr("href","imprimirPackingList.php?peso=1&id="+id_pl_revision);
-		  $("#link_imprimir_pl_sin").attr("target","_blank");
-          $("#link_imprimir_pl_sin").attr("href","imprimirPackingList.php?peso=0&id="+id_pl_revision);
+          $("#link_ver_pl").attr("href","verPackingList.php?id="+id_pl_revision+prodParam);
+                  $("#link_imprimir_pl_con").attr("target","_blank");
+          $("#link_imprimir_pl_con").attr("href","imprimirPackingList.php?peso=1&id="+id_pl_revision+prodParam);
+                  $("#link_imprimir_pl_sin").attr("target","_blank");
+          $("#link_imprimir_pl_sin").attr("href","imprimirPackingList.php?peso=0&id="+id_pl_revision+prodParam);
 		  if ((estado == "Elaboración") || (estado == "Enviado")){
 			  $("#link_eliminar_pl").attr("data-toggle","modal");
 			  $("#link_eliminar_pl").attr("data-target","#eliminarModal_"+id_pl+"_"+id_pl_revision);
@@ -656,10 +661,10 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
 		  }
 		  
 		  
-          $("#link_nueva_seccion").attr("href","nuevaSeccionPackingList.php?id="+id_pl_revision);
+          $("#link_nueva_seccion").attr("href","nuevaSeccionPackingList.php?id="+id_pl_revision+prodParam);
           //$("#link_modificar_pl").attr("href","modificarPackingList.php?id="+id_pl_revision+"&revision="+nro_revision);
-          $("#link_modificar_pl").attr("href","modificarPackingList.php?id_packing_list_revision="+id_pl_revision);
-          $("#link_nueva_despacho").attr("href","nuevoDespacho.php?id_packing_list="+id_pl_revision);
+          $("#link_modificar_pl").attr("href","modificarPackingList.php?id_packing_list_revision="+id_pl_revision+prodParam);
+          $("#link_nueva_despacho").attr("href","nuevoDespacho.php?id_packing_list="+id_pl_revision+prodParam);
         }
       });
 	  
@@ -869,9 +874,9 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
           });
           selectRow(t);
           get_componentes(id_sec)
-          $("#link_ver_seccion_pl").attr("href","verSeccionPackingList.php?id="+id_sec);
-          $("#link_modificar_seccion").attr("href","modificarSeccionPackingList.php?id="+id_sec);
-          $("#link_nuevo_componente").attr("href","nuevoComponentePackingList.php?id="+id_sec);
+          $("#link_ver_seccion_pl").attr("href","verSeccionPackingList.php?id="+id_sec+prodParam);
+          $("#link_modificar_seccion").attr("href","modificarSeccionPackingList.php?id="+id_sec+prodParam);
+          $("#link_nuevo_componente").attr("href","nuevoComponentePackingList.php?id="+id_sec+prodParam);
           $("#link_eliminar_seccion").attr("data-toggle","modal");
           $("#link_eliminar_seccion").attr("data-target","#eliminarModalSeccion_"+id_sec);
         }
@@ -1024,8 +1029,8 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
             $(rowNode).removeClass("selected");
           });
           selectRow(t);
-          $("#link_ver_componente_pl").attr("href","verComponenteSeccionPackingList.php?id="+id_componente);
-          $("#link_modificar_componente").attr("href","modificarComponenteSeccionPackingList.php?id="+id_componente);
+          $("#link_ver_componente_pl").attr("href","verComponenteSeccionPackingList.php?id="+id_componente+prodParam);
+          $("#link_modificar_componente").attr("href","modificarComponenteSeccionPackingList.php?id="+id_componente+prodParam);
           $("#link_eliminar_componente").attr("data-toggle","modal");
           $("#link_eliminar_componente").attr("data-target","#eliminarModalComponente_"+id_componente);
         }

--- a/modificarComponenteSeccionPackingList.php
+++ b/modificarComponenteSeccionPackingList.php
@@ -7,13 +7,17 @@
     
     require 'database.php';
 
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
+
     $id = null;
     if (!empty($_GET['id'])) {
         $id = $_REQUEST['id'];
     }
     
     if (null==$id) {
-        header("Location: listarPackingList.php");
+        header("Location: listarPackingList.php$prodQuery");
     }
     
     if (!empty($_POST)) {
@@ -26,13 +30,13 @@
         $q = $pdo->prepare($sql);
         $q->execute([$_POST['id_conjunto_lista_corte'],$_POST['id_concepto'],$_POST['cantidad'],$_POST['observaciones'],$_POST['id_estado_componente_packing_list'],$_GET['id']]);
 
-		$sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Modificación de componente en sección de packing list','Packing List','verPackingList.php?id=$id')";
+                $sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Modificación de componente en sección de packing list','Packing List','verPackingList.php?id=$id$prodParam')";
 		$q = $pdo->prepare($sql);
 		$q->execute(array($_SESSION['user']['id']));
         
         Database::disconnect();
         
-        header("Location: listarPackingList.php");
+        header("Location: listarPackingList.php$prodQuery");
     } else {
         $pdo = Database::connect();
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -80,7 +84,7 @@
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-				  <form class="form theme-form" role="form" method="post" action="modificarComponenteSeccionPackingList.php?id=<?php echo $id?>">
+                                  <form class="form theme-form" role="form" method="post" action="modificarComponenteSeccionPackingList.php?id=<?php echo $id?><?= $prodParam ?>">
                     <div class="card-body">
                       <div class="row">
 						<div class="col">
@@ -167,7 +171,8 @@
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Modificar</button>
-						<a onclick="document.location.href='listarPackingList.php'" class="btn btn-light">Volver</a>
+                                                <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
+                                                <a onclick="document.location.href='listarPackingList.php<?= $prodQuery ?>'" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/modificarSeccionPackingList.php
+++ b/modificarSeccionPackingList.php
@@ -7,13 +7,17 @@
     
     require 'database.php';
 
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
+
     $id = null;
     if (!empty($_GET['id'])) {
         $id = $_REQUEST['id'];
     }
     
     if (null==$id) {
-        header("Location: listarPackingList.php");
+        header("Location: listarPackingList.php$prodQuery");
     }
     
     if (!empty($_POST)) {
@@ -26,13 +30,13 @@
         $q = $pdo->prepare($sql);
         $q->execute([$_POST['cantidad'],$_POST['observaciones'],$_GET['id']]);
 
-		$sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Modificación de sección de packing list','Packing List','verPackingList.php?id=$id')";
+                $sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Modificación de sección de packing list','Packing List','verPackingList.php?id=$id$prodParam')";
 		$q = $pdo->prepare($sql);
 		$q->execute(array($_SESSION['user']['id']));
         
         Database::disconnect();
         
-        header("Location: listarPackingList.php");
+        header("Location: listarPackingList.php$prodQuery");
     } else {
         $pdo = Database::connect();
         $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -73,7 +77,7 @@
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-				  <form class="form theme-form" role="form" method="post" action="modificarSeccionPackingList.php?id=<?php echo $id?>">
+                                  <form class="form theme-form" role="form" method="post" action="modificarSeccionPackingList.php?id=<?php echo $id?><?= $prodParam ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -93,7 +97,8 @@
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Modificar</button>
-						<a onclick="document.location.href='listarPackingList.php'" class="btn btn-light">Volver</a>
+                                                <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
+                                                <a onclick="document.location.href='listarPackingList.php<?= $prodQuery ?>'" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/nuevaPackingList.php
+++ b/nuevaPackingList.php
@@ -10,6 +10,10 @@ if (empty($_SESSION['user'])) {
 
 require 'database.php';
 
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
+
 if (!empty($_POST)) {
     
   // insert data
@@ -67,7 +71,7 @@ if (!empty($_POST)) {
   $id_packing_list_revision = $pdo->lastInsertId();
 
 
-  $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Nueva Packing List','Listas de Corte','verPackingList.php?id=$id_packing_list_revision')";
+  $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Nueva Packing List','Listas de Corte','verPackingList.php?id=$id_packing_list_revision$prodParam')";
   $q = $pdo->prepare($sql);
   $q->execute(array($_SESSION['user']['id']));
   
@@ -140,7 +144,7 @@ if (!empty($_POST)) {
 
   Database::disconnect();
   //header("Location: listarPackingList.php");
-  header("Location: nuevaPackingListSecciones.php?id_packing_list_revision=".$id_packing_list_revision);
+  header("Location: nuevaPackingListSecciones.php?id_packing_list_revision=".$id_packing_list_revision.$prodParam);
 }?>
 <!DOCTYPE html>
 <html lang="en">
@@ -174,7 +178,7 @@ if (!empty($_POST)) {
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-				          <form class="form theme-form" role="form" method="post" action="nuevaPackingList.php" enctype="multipart/form-data">
+                                          <form class="form theme-form" role="form" method="post" action="nuevaPackingList.php<?= $prodQuery ?>" enctype="multipart/form-data">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -256,14 +260,15 @@ if (!empty($_POST)) {
 							</select>
 							</div>
 							</div>
-						  <input type="hidden" name="id_tarea" value="<?php if (!empty($_GET['idTarea'])) echo $_GET['idTarea'];?>" />
+                                                  <input type="hidden" name="id_tarea" value="<?php if (!empty($_GET['idTarea'])) echo $_GET['idTarea'];?>" />
+                                                  <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>" />
                         </div>
                       </div>
                     </div>
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Crear y agregar Secciones</button>
-						            <a href="listarPackingList.php" class="btn btn-light">Volver</a>
+                                                            <a href="listarPackingList.php<?= $prodQuery ?>" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/nuevaPackingListComponentes.php
+++ b/nuevaPackingListComponentes.php
@@ -6,13 +6,17 @@ if (empty($_SESSION['user'])) {
 }
 require 'database.php';
 
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
+
 $id_packing_list_seccion = null;
 if (!empty($_GET['id_packing_list_seccion'])) {
   $id_packing_list_seccion = $_REQUEST['id_packing_list_seccion'];
 }
 
 if (null==$id_packing_list_seccion) {
-  header("Location: listarPackingList.php");
+  header("Location: listarPackingList.php$prodQuery");
 }
 
 $pdo = Database::connect();
@@ -100,7 +104,7 @@ if (!empty($_POST)) {
       die();
     } else {
       Database::disconnect();
-      header("Location: nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion);
+      header("Location: nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion.$prodParam);
       
     }
 
@@ -165,7 +169,7 @@ if (!empty($_POST)) {
 			  }
 			}
 			  
-			$sql = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Nuevo Componente ID #$id_componente en Seccion de Packing List','Packing List','verPackingList.php?id=$id_packing_list')";
+                    $sql = "INSERT INTO logs (fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Nuevo Componente ID #$id_componente en Seccion de Packing List','Packing List','verPackingList.php?id=$id_packing_list$prodParam')";
 			$q = $pdo->prepare($sql);
 			$q->execute(array($_SESSION['user']['id']));
 
@@ -186,10 +190,10 @@ if (!empty($_POST)) {
 				$q->execute([$id_packing_list_seccion]);
 				$data = $q->fetch(PDO::FETCH_ASSOC);
 
-				header("Location: nuevaPackingListSecciones.php?id_packing_list_revision=".$data["id_packing_list_revision"]);
-			  } else {
-				header("Location: nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion);
-			  }
+                                header("Location: nuevaPackingListSecciones.php?id_packing_list_revision=".$data["id_packing_list_revision"].$prodParam);
+                          } else {
+                                header("Location: nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion.$prodParam);
+                          }
 			}	
 		}
 		
@@ -256,7 +260,7 @@ Database::disconnect();
                       <!-- <a href="#" id="link_ver_componente_lc"><img src="img/eye.png" width="24" height="15" border="0" alt="Ver" title="Ver"></a>&nbsp;&nbsp; -->
                     </h5>
                   </div>
-					        <form class="form theme-form" role="form" method="post" action="nuevaPackingListComponentes.php?id_packing_list_seccion=<?=$id_packing_list_seccion?>">
+                                                <form class="form theme-form" role="form" method="post" action="nuevaPackingListComponentes.php?id_packing_list_seccion=<?=$id_packing_list_seccion?><?= $prodParam ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="form-group col-12">
@@ -355,6 +359,7 @@ Database::disconnect();
                           <label for="observaciones">Observaciones</label>
                           <textarea name="observaciones" id="observaciones" class="form-control"></textarea>
                         </div>
+                        <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                       </div>
                     </div>
                     <div class="card-footer">
@@ -363,7 +368,7 @@ Database::disconnect();
                         <button type="submit" value="2" name="btn2" class="btn btn-primary addComponente">Crear y volver a Secciones</button>
                         <button type="submit" value="3" name="btn3" id="editComponente" class="btn btn-primary d-none">Modificar</button>
                         <button type="button" id="cancelEditComponente" class="btn btn-danger d-none">Cancelar Modificar</button>
-                        <a href='nuevaPackingListSecciones.php?id_packing_list_revision=<?=$data["id_packing_list"]?>' class="btn btn-light">Volver</a>
+                        <a href='nuevaPackingListSecciones.php?id_packing_list_revision=<?=$data["id_packing_list"]?><?= $prodParam ?>' class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>
@@ -434,6 +439,9 @@ Database::disconnect();
     <script src="assets/js/select2/select2.full.min.js"></script>
     <script src="assets/js/select2/select2-custom.js"></script>
     <script>
+      const prod = <?= $prod ?? 0 ?>;
+      const prodQuery = prod ? '?prod=' + prod : '';
+      const prodParam = prod ? '&prod=' + prod : '';
       $(document).ready(function () {
         // Setup - add a text input to each footer cell
         $('#dataTables-example667 tfoot th').each( function () {
@@ -491,7 +499,7 @@ Database::disconnect();
               $(rowNode).removeClass("selected");
             });
             selectRow(t);
-            $("#link_modificar_componente").attr("href","modificarComponentePackingList.php?id="+id_componente);
+            $("#link_modificar_componente").attr("href","modificarComponentePackingList.php?id="+id_componente+prodParam);
             $("#link_modificar_componente").on("click",function(){
               let id_concepto = t.find("td:nth-child(2)").data("id");
               let id_conjunto = t.find("td:nth-child(3)").data("id");
@@ -526,7 +534,7 @@ Database::disconnect();
         if(id_componente!="" && id_componente>0){
           let modal=$("#eliminarComponente")
           modal.modal("show")
-          modal.find(".modal-footer a").attr("href","eliminarComponentePackingList.php?id="+id_componente)
+          modal.find(".modal-footer a").attr("href","eliminarComponentePackingList.php?id="+id_componente+prodParam)
         }
       });
 

--- a/nuevaPackingListSecciones.php
+++ b/nuevaPackingListSecciones.php
@@ -5,6 +5,9 @@ if (empty($_SESSION['user'])) {
   die("Redirecting to index.php");
 }
 require 'database.php';
+$prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+$prodQuery = $prod ? '?prod=' . $prod : '';
+$prodParam = $prod ? '&prod=' . $prod : '';
 if (!empty($_POST)) {
     
   // insert data
@@ -20,11 +23,11 @@ if (!empty($_POST)) {
 
     if(isset($_POST['btn2'])){
       $id_packing_list_seccion=$_POST['btn2'];
-      $redirect="nuevaPackingListSecciones.php?id_packing_list_revision=".$_GET["id_packing_list_revision"];
+      $redirect="nuevaPackingListSecciones.php?id_packing_list_revision=".$_GET["id_packing_list_revision"].$prodParam;
     }
     if(isset($_POST['btn3'])){
       $id_packing_list_seccion=$_POST['btn3'];
-      $redirect="nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion;
+      $redirect="nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion.$prodParam;
     }
 
     $sql = "UPDATE packing_lists_secciones SET cantidad = ?, observaciones = ? WHERE id = ?";
@@ -48,7 +51,7 @@ if (!empty($_POST)) {
     $q = $pdo->prepare($sql);
     $q->execute(array($_SESSION['user']['id']));
 
-    $redirect="nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion;
+    $redirect="nuevaPackingListComponentes.php?id_packing_list_seccion=".$id_packing_list_seccion.$prodParam;
   }
 
   Database::disconnect();
@@ -104,7 +107,7 @@ Database::disconnect();
                       }*/?>
                     </h5>
                   </div>
-					        <form class="form theme-form" role="form" method="post" action="nuevaPackingListSecciones.php?id_packing_list_revision=<?=$id_packing_list_revision?>">
+                                                <form class="form theme-form" role="form" method="post" action="nuevaPackingListSecciones.php?id_packing_list_revision=<?=$id_packing_list_revision?><?= $prodParam ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -154,6 +157,7 @@ Database::disconnect();
                             </div>
                           </div>
                           
+                        <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                         </div>
                       </div>
                     </div>
@@ -166,7 +170,7 @@ Database::disconnect();
                         <button type="submit" value="2" name="btn2" id="editSeccion" class="btn btn-success d-none">Modificar</button>
                         <button type="submit" value="3" name="btn3" id="editSeccionGoComponentes" class="btn btn-primary d-none">Modificar e ir a Componentes</button>
                         <button type="button" id="cancelEditSeccion" class="btn btn-light d-none">Cancelar Modificar</button>
-                        <a href='listarPackingList.php' id="volverPackingList" class="btn btn-light">Volver al Packing list</a>
+                        <a href='listarPackingList.php<?= $prodQuery ?>' id="volverPackingList" class="btn btn-light">Volver al Packing list</a>
                       </div>
                     </div>
                   </form>
@@ -237,6 +241,9 @@ Database::disconnect();
     <script src="assets/js/select2/select2.full.min.js"></script>
     <script src="assets/js/select2/select2-custom.js"></script>
     <script>
+      const prod = <?= $prod ?? 0 ?>;
+      const prodQuery = prod ? '?prod=' + prod : '';
+      const prodParam = prod ? '&prod=' + prod : '';
       $(document).ready(function () {
         // Setup - add a text input to each footer cell
         $('#dataTables-example667 tfoot th').each( function () {
@@ -297,7 +304,7 @@ Database::disconnect();
               $(rowNode).removeClass("selected");
             });
             selectRow(t);
-            $("#link_ver_seccion_pl").attr("href","verSeccionPackingList.php?id="+id_seccion);
+            $("#link_ver_seccion_pl").attr("href","verSeccionPackingList.php?id="+id_seccion+prodParam);
             //$("#link_modificar_seccion").attr("href","modificarPackingListSeccion.php?id="+id_seccion);
             $("#link_modificar_seccion").on("click",function(){
               let cantidad = t.find("td:nth-child(3)").html();
@@ -317,7 +324,7 @@ Database::disconnect();
             })
             //$("#link_eliminar_seccion").attr("href","eliminarSeccionPackingList.php?id="+id_seccion);
             $("#link_eliminar_seccion").data("id",id_seccion);
-            $("#link_nueva_componente").attr("href","nuevaPackingListComponentes.php?id_packing_list_seccion="+id_seccion);
+            $("#link_nueva_componente").attr("href","nuevaPackingListComponentes.php?id_packing_list_seccion="+id_seccion+prodParam);
           }
         });
     
@@ -328,7 +335,7 @@ Database::disconnect();
         if(id_seccion!="" && id_seccion>0){
           let modal=$("#eliminarSeccion")
           modal.modal("show")
-          modal.find(".modal-footer a").attr("href","eliminarSeccionPackingList.php?id="+id_seccion)
+          modal.find(".modal-footer a").attr("href","eliminarSeccionPackingList.php?id="+id_seccion+prodParam)
         }
       });
 

--- a/nuevaSeccionPackingList.php
+++ b/nuevaSeccionPackingList.php
@@ -6,7 +6,11 @@
     }
     
     require 'database.php';
-    
+
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
+
     if (!empty($_POST)) {
         
         // insert data
@@ -17,12 +21,12 @@
         $q = $pdo->prepare($sql);
         $q->execute([$_GET['id'],$_POST['cantidad'],$_POST['observaciones']]);
         
-		$sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Nueva Sección de Packing List','Packing List','verPackingList.php?id=$id')";
+                $sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Nueva Sección de Packing List','Packing List','verPackingList.php?id=$id$prodParam')";
 		$q = $pdo->prepare($sql);
 		$q->execute(array($_SESSION['user']['id']));
 		
         Database::disconnect();
-        header("Location: listarPackingList.php");
+        header("Location: listarPackingList.php$prodQuery");
     }
     
 ?>
@@ -54,7 +58,7 @@
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-					<form class="form theme-form" role="form" method="post" action="nuevaSeccionPackingList.php?id=<?php echo $_GET['id']?>">
+                                        <form class="form theme-form" role="form" method="post" action="nuevaSeccionPackingList.php?id=<?php echo $_GET['id']?><?= $prodParam ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -73,7 +77,8 @@
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
                         <button class="btn btn-primary" type="submit">Crear</button>
-						<a href="listarPackingList.php" class="btn btn-light">Volver</a>
+                                                <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
+                                                <a href="listarPackingList.php<?= $prodQuery ?>" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/nuevoComponentePackingList.php
+++ b/nuevoComponentePackingList.php
@@ -6,6 +6,10 @@
     }
     
     require 'database.php';
+
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
     
     if (!empty($_POST)) {
         
@@ -17,12 +21,12 @@
         $q = $pdo->prepare($sql);
         $q->execute([$_GET['id'],$_POST['id_conjunto_lista_corte'],$_POST['id_concepto'],$_POST['cantidad'],$_POST['observaciones']]);
         
-		$sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Nuevo Componente de Sección en Packing List','Packing List','verPackingList.php?id=$id')";
+                $sql = "INSERT INTO logs(`fecha_hora`, `id_usuario`, `detalle_accion`,`modulo`,link) VALUES (now(),?,'Nuevo Componente de Sección en Packing List','Packing List','verPackingList.php?id=$id$prodParam')";
 		$q = $pdo->prepare($sql);
 		$q->execute(array($_SESSION['user']['id']));
 		
         Database::disconnect();
-        header("Location: listarPackingList.php");
+        header("Location: listarPackingList.php$prodQuery");
     } 
 	$pdo = Database::connect();
 	$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
@@ -64,7 +68,7 @@
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-					<form class="form theme-form" role="form" method="post" action="nuevoComponentePackingList.php?id=<?php echo $_GET['id']?>">
+                                        <form class="form theme-form" role="form" method="post" action="nuevoComponentePackingList.php?id=<?php echo $_GET['id']?><?= $prodParam ?>">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -112,17 +116,18 @@
 							<label class="col-sm-3 col-form-label">Cantidad(*)</label>
 							<div class="col-sm-9"><input name="cantidad" type="number" step="0.01" class="form-control" required="required"></div>
 						  </div>
-						  <div class="form-group row">
-							<label class="col-sm-3 col-form-label">Observaciones(*)</label>
-							<div class="col-sm-9"><textarea name="observaciones" class="form-control" required="required"></textarea></div>
-						  </div>
+                                                  <div class="form-group row">
+                                                        <label class="col-sm-3 col-form-label">Observaciones(*)</label>
+                                                        <div class="col-sm-9"><textarea name="observaciones" class="form-control" required="required"></textarea></div>
+                                                  </div>
+                                                  <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
                         </div>
                       </div>
                     </div>
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
 						<button class="btn btn-primary" type="submit">Crear</button>
-						<a href="listarPackingList.php" class="btn btn-light">Volver</a>
+                                                <a href="listarPackingList.php<?= $prodQuery ?>" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>

--- a/verSeccionPackingList.php
+++ b/verSeccionPackingList.php
@@ -7,13 +7,17 @@
     
     require 'database.php';
 
+    $prod = isset($_REQUEST['prod']) ? (int)$_REQUEST['prod'] : null;
+    $prodQuery = $prod ? '?prod=' . $prod : '';
+    $prodParam = $prod ? '&prod=' . $prod : '';
+
     $id = null;
     if (!empty($_GET['id'])) {
         $id = $_REQUEST['id'];
     }
     
     if (null==$id) {
-        header("Location: listarPackingList.php");
+        header("Location: listarPackingList.php$prodQuery");
     }
     
     if (!empty($_POST)) {
@@ -59,7 +63,7 @@
                   <div class="card-header">
                     <h5><?=$ubicacion?></h5>
                   </div>
-				  <form class="form theme-form" role="form" method="post" action="#">
+                                  <form class="form theme-form" role="form" method="post" action="#">
                     <div class="card-body">
                       <div class="row">
                         <div class="col">
@@ -77,7 +81,8 @@
                     </div>
                     <div class="card-footer">
                       <div class="col-sm-9 offset-sm-3">
-						<a onclick="document.location.href='listarPackingList.php'" class="btn btn-light">Volver</a>
+                                                <input type="hidden" name="prod" value="<?= $_REQUEST['prod'] ?? '' ?>">
+                                                <a onclick="document.location.href='listarPackingList.php<?= $prodQuery ?>'" class="btn btn-light">Volver</a>
                       </div>
                     </div>
                   </form>


### PR DESCRIPTION
## Summary
- carry `prod` parameter through new packing list, section, and component forms
- include `prod` in listing links, redirects, and auxiliary scripts
- ensure logs and navigation keep environment context via hidden fields

## Testing
- `php -l eliminarComponentePackingList.php`
- `php -l eliminarSeccionPackingList.php`
- `php -l imprimirPackingList.php`
- `php -l listarPackingList.php`
- `php -l modificarComponenteSeccionPackingList.php`
- `php -l modificarSeccionPackingList.php`
- `php -l nuevaPackingList.php`
- `php -l nuevaPackingListComponentes.php`
- `php -l nuevaPackingListSecciones.php`
- `php -l nuevaSeccionPackingList.php`
- `php -l nuevoComponentePackingList.php`
- `php -l verSeccionPackingList.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8697aa0a08321954a69356200bedb