### PR TITLE
feat: agrupar conjuntos en nueva OT

### DIFF
--- a/nuevaOrdenTrabajo.php
+++ b/nuevaOrdenTrabajo.php
@@ -68,10 +68,50 @@ function LCPermiteOR($pdo, $id_lista_corte){
 }
 
 function obtenerDatosListaCorte($pdo, $id_lista_corte){
-  $sql = "SELECT id AS id_lista_corte_revision, nombre, numero AS numero_lc, id_estado_lista_corte, id_proyecto, nro_revision, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido FROM listas_corte WHERE id = ?";
+  $sql = "SELECT id AS id_lista_corte_revision, nombre, numero AS numero_lc, id_estado_lista_corte, id_proyecto, nro_revision, id_cuenta_realizo, id_cuenta_reviso, id_cuenta_valido FROM listas_corte WHERE id = ?"; 
   $q = $pdo->prepare($sql);
   $q->execute([$id_lista_corte]);
   return $q->fetch(PDO::FETCH_ASSOC);
+}
+
+function obtenerDatosConjuntos($pdo,$id_lista_corte){
+  $conjuntos=[];
+  $sql="SELECT id, nombre, cantidad FROM listas_corte_conjuntos WHERE id_lista_corte = ? ORDER BY id";
+  $q=$pdo->prepare($sql);
+  $q->execute([$id_lista_corte]);
+  while($conj=$q->fetch(PDO::FETCH_ASSOC)){
+    $sqlPos="SELECT lcp.id, lcp.posicion, lcp.cantidad AS cant_pos, m.concepto, GROUP_CONCAT(DISTINCT tp.tipo SEPARATOR ',') AS procesos, COALESCE(otd.cant_bajada_total,0) AS cant_bajada_total
+              FROM lista_corte_posiciones lcp
+              JOIN lista_corte_procesos lcpr ON lcpr.id_lista_corte_posicion = lcp.id
+              JOIN materiales m ON lcp.id_material = m.id
+              JOIN tipos_procesos tp ON lcpr.id_tipo_proceso = tp.id
+              LEFT JOIN (
+                SELECT id_posicion, SUM(cantidad) AS cant_bajada_total
+                FROM ordenes_trabajo_detalle
+                GROUP BY id_posicion
+              ) otd ON otd.id_posicion = lcp.id
+              WHERE lcp.id_lista_corte_conjunto = ?
+              GROUP BY lcp.id";
+    $qPos=$pdo->prepare($sqlPos);
+    $qPos->execute([$conj['id']]);
+    $posiciones=[];
+    $saldo_conj=$conj['cantidad'];
+    while($pos=$qPos->fetch(PDO::FETCH_ASSOC)){
+      $cant_total=$conj['cantidad']*$pos['cant_pos'];
+      $saldo=$cant_total-$pos['cant_bajada_total'];
+      $pos['cant_total']=$cant_total;
+      $pos['saldo']=$saldo;
+      $posiciones[]=$pos;
+      $sets_disp=$pos['cant_pos']>0 ? floor($saldo/$pos['cant_pos']) : 0;
+      if($sets_disp<$saldo_conj){
+        $saldo_conj=$sets_disp;
+      }
+    }
+    $conj['posiciones']=$posiciones;
+    $conj['saldo']=$saldo_conj;
+    $conjuntos[]=$conj;
+  }
+  return $conjuntos;
 }
 
 if (!empty($_POST)) {
@@ -295,6 +335,11 @@ if (!empty($_POST)) {
 $id_proyecto=$data_ot['id_proyecto'];
 $descProyecto=getDescripcionProyecto($pdoTmp,$id_proyecto);
 
+$pdoList = Database::connect();
+$pdoList->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$conjuntosLC = obtenerDatosConjuntos($pdoList,$id_lista_corte);
+Database::disconnect();
+
 ?>
 
 <!DOCTYPE html>
@@ -365,123 +410,29 @@ $descProyecto=getDescripcionProyecto($pdoTmp,$id_proyecto);
                       </h5>
                     </div>
                     <div class="card-body">
-                      <div class="form-group row mb-3">
-                        <div class="col-sm-3 mb-2 mb-sm-0">
-                          <select id="filtro_conjunto" class="form-control" style="width:100%" multiple></select>
-                        </div>
-                        <div class="col-sm-3 mb-2 mb-sm-0">
-                          <select id="filtro_proceso" class="form-control" style="width:100%" multiple></select>
-                        </div>
-                        <div class="col-sm-3 mb-2 mb-sm-0">
-                          <select id="filtro_material" class="form-control" style="width:100%" multiple></select>
-                        </div>
-                        <div class="col-sm-3">
-                          <button type="button" id="toggle_seleccion" class="btn btn-primary w-100">Seleccionar visibles</button>
-                        </div>
-                      </div>
-                      <div class="form-group row">
-                        <div class="dt-ext table-responsive">
-                          <table class="display" id="tablaLC">
-                            <thead>
-                              <tr>
-                                <th class="d-none">ID Posicion</th>
-                                <th>Conjunto</th>
-                                <th>Cant. conj.</th>
-                                <th>Posicion</th>
-                                <th>Cant. pos.</th>
-                                <th>Cant. total</th>
-                                <th>Material</th>
-                                <th>Procesos</th>
-                                <th>Cant. bajada</th>
-                                <th>Saldo</th>
+                      <!--Listado de conjuntos-->
+                      <div class="dt-ext table-responsive">
+                        <table class="display" id="tablaLC">
+                          <thead>
+                            <tr>
+                              <th></th>
+                              <th>Conjunto</th>
+                              <th>Cant. conj.</th>
+                              <th>Saldo</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <?php foreach($conjuntosLC as $conj){ 
+                              $json = htmlspecialchars(json_encode($conj['posiciones']), ENT_QUOTES, 'UTF-8'); ?>
+                              <tr data-posiciones='<?=$json?>' data-nombre='<?=htmlspecialchars($conj['nombre'],ENT_QUOTES)?>' data-cantconj='<?=$conj['cantidad']?>' data-saldo='<?=$conj['saldo']?>'>
+                                <td class="details-control"></td>
+                                <td><?=htmlspecialchars($conj['nombre'])?></td>
+                                <td class="text-end"><?=$conj['cantidad']?></td>
+                                <td class="text-end"><?=$conj['saldo']?></td>
                               </tr>
-                            </thead>
-                            <tfoot>
-                              <tr>
-                                <th class="d-none">ID Posicion</th>
-                                <th>Conjunto</th>
-                                <th>Cant. conj.</th>
-                                <th>Posicion</th>
-                                <th>Cant. pos.</th>
-                                <th>Cant. total</th>
-                                <th>Material</th>
-                                <th>Procesos</th>
-                                <th>Cant. bajada</th>
-                                <th>Saldo</th>
-                              </tr>
-                            </tfoot>
-                            <tbody><?php
-                              $pdo = Database::connect();
-                              $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-                              $posiciones_agregadas=[];
-                              //$sql = " SELECT lcc.nombre,lcc.cantidad AS cant_conj,lcp.posicion,lcp.cantidad AS cant_pos,m.concepto,GROUP_CONCAT(tp.tipo SEPARATOR ',' ) AS procesos, lcp.id AS id_posicion,COALESCE(SUM(otd.cantidad),0) AS cant_bajada_total,COALESCE(SUM(CASE WHEN otd.id_orden_trabajo = ? THEN otd.cantidad END),0) AS cant_bajada_ot FROM listas_corte_conjuntos lcc INNER JOIN lista_corte_posiciones lcp ON lcp.id_lista_corte_conjunto=lcc.id INNER JOIN lista_corte_procesos lcpr ON lcpr.id_lista_corte_posicion=lcp.id INNER JOIN materiales m ON lcp.id_material=m.id INNER JOIN tipos_procesos tp ON lcpr.id_tipo_proceso=tp.id LEFT JOIN ordenes_trabajo_detalle otd ON otd.id_posicion=lcp.id WHERE lcc.id_lista_corte = ? GROUP BY otd.id_orden_trabajo, lcp.id";
-                              $sql = "SELECT lcc.nombre, lcc.cantidad AS cant_conj,
-                                lcp.posicion, lcp.cantidad AS cant_pos,
-                                m.concepto,
-                                GROUP_CONCAT(DISTINCT tp.tipo SEPARATOR ',') AS procesos,
-                                lcp.id AS id_posicion,
-                                COALESCE(otd.cant_bajada_total,0) AS cant_bajada_total,
-                                COALESCE(otd.cant_bajada_ot,0)     AS cant_bajada_ot
-                              FROM listas_corte_conjuntos lcc
-                              JOIN lista_corte_posiciones lcp ON lcp.id_lista_corte_conjunto = lcc.id
-                              JOIN lista_corte_procesos lcpr ON lcpr.id_lista_corte_posicion = lcp.id
-                              JOIN materiales m ON lcp.id_material = m.id
-                              JOIN tipos_procesos tp ON lcpr.id_tipo_proceso = tp.id
-                              LEFT JOIN (
-                                SELECT id_posicion,
-                                  SUM(cantidad) AS cant_bajada_total,
-                                  SUM(CASE WHEN id_orden_trabajo = ? THEN cantidad END) AS cant_bajada_ot
-                                FROM ordenes_trabajo_detalle
-                                GROUP BY id_posicion
-                              ) otd ON otd.id_posicion = lcp.id
-                              WHERE lcc.id_lista_corte = ?
-                              GROUP BY lcp.id
-                              ORDER BY lcp.id";
-
-                              //echo $sql;
-                              $q = $pdo->prepare($sql);
-                              $q->execute([$editing ? $id_orden_trabajo : 0,$id_lista_corte]);
-                              while ($row = $q->fetch(PDO::FETCH_ASSOC)) {
-                                $total_bajada = $row['cant_bajada_total'];
-                                $cant_ot      = $row['cant_bajada_ot'];
-                                $cant_otros   = $total_bajada - $cant_ot;
-                                $cant_total   = $row['cant_conj'] * $row['cant_pos'];
-                                $saldo        = $cant_total - $total_bajada;
-                                $style = "";
-                                if ($editing && $cant_ot > 0) {
-                                  $posiciones_agregadas[] = [
-                                    'id_posicion'       => $row['id_posicion'],
-                                    'nombre'            => $row['nombre'],
-                                    'cant_conj'         => $row['cant_conj'],
-                                    'posicion'          => $row['posicion'],
-                                    'cant_pos'          => $row['cant_pos'],
-                                    'concepto'          => $row['concepto'],
-                                    'procesos'          => $row['procesos'],
-                                    'cant_bajada'       => $cant_ot,
-                                    'cant_bajada_otros' => $cant_otros
-                                  ];
-                                  $cant_bajada=$cant_otros;
-                                  $style = " display: none;";
-                                } else {
-                                  $cant_bajada=$total_bajada;
-                                }?>
-                                <tr id="<?=$row['id_posicion']?>" data-cant-bajada="<?=$cant_bajada?>" data-cant-total="<?=$cant_total?>" style="<?=$style?>">
-                                  <td class="d-none"><?=$row['id_posicion']?></td>
-                                  <td><?=$row['nombre']?></td>
-                                  <td class="text-end"><?=$row['cant_conj']?></td>
-                                  <td class="text-end"><?=$row['posicion']?></td>
-                                  <td class="text-end"><?=$row['cant_pos']?></td>
-                                  <td class="text-end"><?=$cant_total?></td>
-                                  <td><?=$row['concepto']?></td>
-                                  <td><?=$row['procesos']?></td>
-                                  <td class="text-end"><?=$cant_bajada?></td>
-                                  <td class="text-end"><?=$saldo?></td>
-                                </tr><?php
-                              }
-                              Database::disconnect();?>
-                            </tbody>
-                          </table>
-                        </div>
+                            <?php } ?>
+                          </tbody>
+                        </table>
                       </div>
                     </div>
                   </div>
@@ -497,57 +448,17 @@ $descProyecto=getDescripcionProyecto($pdoTmp,$id_proyecto);
                       <div class="form-group row">
                         <div class="dt-ext table-responsive">
                           <table class="display" id="tablaOT">
-                          <thead>
+                            <thead>
                               <tr>
-                                <th class="d-none">ID Posicion</th>
-                                <th>Conjunto</th>
-                                <th style="width:80px">Cant. conj.</th>
-                                <th style="width:80px">Posicion</th>
-                                <th style="width:80px">Cant. pos.</th>
-                                <th style="width:90px">Cant. total</th>
-                                <th style="min-width:220px">Material</th>
-                                <th style="min-width:150px">Procesos</th>
-                                <th style="width:90px">Saldo</th>
-                                <th style="width:90px">Cant. a Bajar</th>
-                              </tr>
-                            </thead>
-                            <tfoot>
-                              <tr>
-                                <th class="d-none">ID Posicion</th>
+                                <th class="d-none">ID</th>
                                 <th>Conjunto</th>
                                 <th>Cant. conj.</th>
-                                <th>Posicion</th>
-                                <th>Cant. pos.</th>
-                                <th>Cant. total</th>
-                                <th>Material</th>
-                                <th>Procesos</th>
-                                <th>Saldo</th>
-                                <th>Cant. a Bajar</th>
+                                <th>Saldo conj.</th>
+                                <th>Cant. conj. a bajar</th>
                               </tr>
-                            </tfoot>
-                            <tbody><?php
-                              if($editing){
-                                foreach($posiciones_agregadas as $row){
-                                  $cant_total = $row['cant_conj']*$row['cant_pos'];
-                                  $max = $cant_total - $row['cant_bajada_otros'];
-                                  $saldo = $max - $row['cant_bajada'];?>
-                                  <tr id="<?=$row['id_posicion']?>">
-                                    <td class="d-none"><?=$row['id_posicion']?></td>
-                                    <td><?=$row['nombre']?></td>
-                                    <td class="text-end"><?=$row['cant_conj']?></td>
-                                    <td class="text-end"><?=$row['posicion']?></td>
-                                    <td class="text-end"><?=$row['cant_pos']?></td>
-                                    <td class="text-end"><?=$cant_total?></td>
-                                    <td><?=$row['concepto']?></td>
-                                    <td><?=$row['procesos']?></td>
-                                    <td class="text-end"><?=$saldo?></td>
-                                    <td>
-                                      <input type="hidden" name="id_posicion[]" value="<?=$row['id_posicion']?>">
-                                      <input type="number" step="1" class="form-control cantidad-bajar" name="cantidad_bajar[]" value="<?=$row['cant_bajada']?>" max="<?=$max?>" data-saldo="<?=$max?>" min="0">
-                                    </td>
-                                  </tr><?php
-                                }
-                              }?>
+                            </thead>
+                            <tbody>
+                              <?php // al editar no se soporta la vista por conjuntos, se mostrará vacío ?>
                             </tbody>
                           </table>
                         </div>
@@ -650,332 +561,117 @@ $descProyecto=getDescripcionProyecto($pdoTmp,$id_proyecto);
     <script src="assets/js/select2/select2.full.min.js"></script>
     <script src="assets/js/select2/select2-custom.js"></script>
     <script>
-      var tablaLC = $('#tablaLC');
-      var tablaOT = $('#tablaOT');
-      var tablaLCDT, dtOT;
+      $(function(){
+        var tablaLC = $('#tablaLC');
+        var tablaOT = $('#tablaOT');
+        var tablaLCDT, dtOT;
 
-      $(document).ready(function () {
-
-        let datatableDefault={
-          stateSave: false,
-          responsive: false,
-          language: {
-            "decimal": "",
-            "emptyTable": "No hay información",
-            "info": "Mostrando _START_ a _END_ de _TOTAL_ Registros",
-            "infoEmpty": "Mostrando 0 to 0 of 0 Registros",
-            "infoFiltered": "(Filtrado de _MAX_ total registros)",
-            "infoPostFix": "",
-            "thousands": ",",
-            "lengthMenu": "Mostrar _MENU_ Registros",
-            "loadingRecords": "Cargando...",
-            "processing": "Procesando...",
-            "search": "Buscar:",
-            "zeroRecords": "No hay resultados",
-            "paginate": {
-              "first": "Primero",
-              "last": "Ultimo",
-              "next": "Siguiente",
-              "previous": "Anterior"
-            }
-          }
+        function formatPosiciones(json){
+          var rows = JSON.parse(json);
+          var html = '<table class="table table-sm mb-0"><thead><tr><th class="d-none">ID</th><th>Posición</th><th>Cant. pos.</th><th>Cant. total</th><th>Material</th><th>Procesos</th><th>Saldo</th></tr></thead><tbody>';
+          rows.forEach(function(p){
+            html += '<tr>'+
+                    '<td class="d-none">'+p.id+'</td>'+
+                    '<td>'+p.posicion+'</td>'+
+                    '<td class="text-end">'+p.cant_pos+'</td>'+
+                    '<td class="text-end">'+p.cant_total+'</td>'+
+                    '<td>'+p.concepto+'</td>'+
+                    '<td>'+p.procesos+'</td>'+
+                    '<td class="text-end">'+p.saldo+'</td>'+
+                    '</tr>';
+          });
+          html += '</tbody></table>';
+          return html;
         }
 
-        // Setup - add a text input to each footer cell
-        tablaLC.find('tfoot th').each( function () {
-          var title = $(this).text();
-          if(title !== '' && !$(this).hasClass('d-none')){
-            $(this).html( '<input type="text" size="'+title.length+'" placeholder="'+title+'" />' );
-          }
-        } );
-
-        tablaLCDT = tablaLC.DataTable(Object.assign({}, datatableDefault, {
-          columnDefs: [
-            { targets: 0, visible: false },
-            { targets: 1, width: '100px' },
-            { targets: 2, width: '40px' },
-            { targets: 3, width: '40px' },
-            { targets: 4, width: '40px' },
-            { targets: 5, width: '40px' },
-            { targets: 6, width: '220px' },
-            { targets: 7, width: '100px' },
-            { targets: 8, width: '40px' },
-            { targets: 9, width: '40px' }
-          ],
-          select: {
-            style: 'multi'
-          },
-          order: [[0, 'asc']]
-        }));
-
-        tablaLCDT.on('select deselect', updateToggleButton);
-
-        //populate filtros
-        var conjuntos = tablaLCDT.column(1).data().unique().sort();
-        //$('#filtro_conjunto').append('<option value="">- Todos los conjuntos -</option>');
-        conjuntos.each(function(d){
-          $('#filtro_conjunto').append('<option value="'+d+'">'+d+'</option>');
-        });
-        var materiales = tablaLCDT.column(6).data().unique().sort();
-        materiales.each(function(m){
-          $('#filtro_material').append('<option value="'+m+'">'+m+'</option>');
-        });
-        var procesosSet = new Set();
-        tablaLCDT.column(7).data().each(function(d){
-          d.split(',').forEach(function(p){
-            procesosSet.add(p.trim());
-          });
-        });
-        //$('#filtro_proceso').append('<option value="">- Todos los procesos -</option>');
-        Array.from(procesosSet).sort().forEach(function(p){
-          $('#filtro_proceso').append('<option value="'+p+'">'+p+'</option>');
+        tablaLCDT = tablaLC.DataTable({
+          columnDefs:[{targets:0,orderable:false,className:'details-control',defaultContent:''}],
+          select:{style:'multi',selector:'td:not(.details-control)'},
+          order:[[1,'asc']]
         });
 
-        $('#filtro_conjunto').select2({placeholder:'Conjunto',allowClear:true});
-        $('#filtro_proceso').select2({placeholder:'Proceso',allowClear:true});
-        $('#filtro_material').select2({placeholder:'Material',allowClear:true});
-
-        $('#filtro_conjunto').on('change', function () {
-          var selected = $(this).val(); // array de valores seleccionados
-          var search = selected && selected.length
-            ? selected.map(val => '^' + $.fn.dataTable.util.escapeRegex(val) + '$').join('|')
-            : '';
-          tablaLCDT.column(1).search(search, true, false).draw(); // regex=true, smart=false
-        });
-
-        $('#filtro_proceso').on('change', function () {
-          var selected = $(this).val();
-          var search = selected && selected.length
-            ? selected.map(val => $.fn.dataTable.util.escapeRegex(val)).join('|')
-            : '';
-          tablaLCDT.column(7).search(search, true, false).draw();
-        });
-
-        $('#filtro_material').on('change', function () {
-          var selected = $(this).val();
-          var search = selected && selected.length
-            ? selected.map(val => '^' + $.fn.dataTable.util.escapeRegex(val) + '$').join('|')
-            : '';
-          tablaLCDT.column(6).search(search, true, false).draw();
-        });
-
-
-        // Apply the search
-        tablaLCDT.columns().every( function () {
-          var that = this;
-          $( 'input', this.footer() ).on( 'keyup change', function () {
-            if ( that.search() !== this.value ) {
-              that.search( this.value ).draw();
-            }
-          });
-        } );
-        // Botón para seleccionar o deseleccionar según estado
-        $('#toggle_seleccion').on('click', function(){
-          var rows = tablaLCDT.rows({search:'applied'});
-          var allSelected = rows.count() > 0 && rows.count() === tablaLCDT.rows({search:'applied', selected:true}).count();
-
-          if(allSelected){
-            rows.deselect();
-          } else {
-            rows.select();
-          }
-
-          updateToggleButton();
-        });
-
-        tablaLCDT.on('draw', updateToggleButton);
-
-        updateToggleButton();
-
-        $("#link_agregar_posiciones").on("click", function () {
-          var selectedRowsLC = tablaLCDT.rows({ selected: true });
-          if (selectedRowsLC.count() > 0) {
-            let newData = selectedRowsLC.data().map(function (elemento) {
-              // elemento[0] = ID Posición (col oculta en LC) — lo fuerzo a número (mejor orden numérico)
-              let idPos   = parseInt(elemento[0], 10);
-              let saldo   = elemento[9]; // Saldo visible en LC
-              let inputCantidad = `
-                <input type="hidden" name="id_posicion[]" value="${elemento["DT_RowId"]}">
-                <input type="number" step="1" class="form-control cantidad-bajar"
-                      name="cantidad_bajar[]" value="${saldo}" data-saldo="${saldo}" max="${saldo}" min="0">
-                <div class="invalid-feedback">La cantidad no puede superar el saldo (${saldo}).</div>
-              `;
-              return [
-                idPos,        // <-- nueva col 0 en OT (oculta)
-                elemento[1],
-                elemento[2],
-                elemento[3],
-                elemento[4],
-                elemento[5],
-                elemento[6],
-                elemento[7],
-                saldo,        // Saldo (col 8, 0-based)
-                inputCantidad // Cant. a Bajar (col 9)
-              ];
-            });
-
-            dtOT.rows.add(newData);
-            dtOT.order([0, 'asc']).draw(false); // <— re-ordenar por ID después de agregar
-
-            $(selectedRowsLC.nodes()).hide();
-            selectedRowsLC.deselect();
-            refreshCantidades();
-          } else {
-            alert("Por favor seleccione una posicion para agregar a la Orden de trabajo");
+        $('#tablaLC tbody').on('click','td.details-control',function(){
+          var tr=$(this).closest('tr');
+          var row=tablaLCDT.row(tr);
+          var data=tr.data('posiciones');
+          if(row.child.isShown()){
+            row.child.hide();
+            tr.removeClass('shown');
+          }else{
+            row.child(formatPosiciones(data)).show();
+            tr.addClass('shown');
           }
         });
 
-		
-		    // Setup - add a text input to each footer cell
-        tablaOT.find('tfoot th').each(function(){
-          var title = $(this).text();
-          if(title !== '' && !$(this).hasClass('d-none')){
-            $(this).html( '<input type="text" size="'+title.length+'" placeholder="'+title+'" />' );
-          }
+        $('#tablaLC tbody').on('click','tr',function(e){
+          if($(e.target).hasClass('details-control')) return;
+          $(this).toggleClass('selected');
         });
 
         dtOT = tablaOT.DataTable({
-          stateSave: false,
-          responsive: false,
-          columnDefs: [
-            { targets: 0, visible: false, searchable: false } // ID Posición oculto
-          ],
-          order: [[0, 'asc']],
-          language: {
-          "decimal": "",
-          "emptyTable": "No hay información",
-          "info": "Mostrando _START_ a _END_ de _TOTAL_ Registros",
-          "infoEmpty": "Mostrando 0 to 0 of 0 Registros",
-          "infoFiltered": "(Filtrado de _MAX_ total registros)",
-          "infoPostFix": "",
-          "thousands": ",",
-          "lengthMenu": "Mostrar _MENU_ Registros",
-          "loadingRecords": "Cargando...",
-          "processing": "Procesando...",
-          "search": "Buscar:",
-          "zeroRecords": "No hay resultados",
-          "paginate": {
-              "first": "Primero",
-              "last": "Ultimo",
-              "next": "Siguiente",
-              "previous": "Anterior"
-          }}
-        });
-		
-        $(document).on("click", "#tablaOT tbody tr td", function () {
-          var $tr = $(this).parent();
-          var celdaConInput = $tr.find("input[name='cantidad_bajar[]']").closest('td')[0]; // <— sin hardcodear índice
-
-          if (this !== celdaConInput) {
-            if ($tr.hasClass('selected')) {
-              deselectRow($tr);
-            } else {
-              dtOT.rows().nodes().each(function (rowNode) { $(rowNode).removeClass("selected"); });
-              selectRow($tr);
-            }
-          }
+          columnDefs:[{targets:0,visible:false}],
+          order:[[1,'asc']]
         });
 
-        // Apply the search
-        tablaOT.DataTable().columns().every( function () {
-          var that = this;
-          $( 'input', this.footer() ).on( 'keyup change', function () {
-            if ( that.search() !== this.value ) {
-              that.search( this.value ).draw();
-            }
+        function formatPosicionesOT(posiciones,cant){
+          var html='<table class="table table-sm mb-0"><thead><tr><th class="d-none">ID</th><th>Posición</th><th>Cant. pos.</th><th>Material</th><th>Procesos</th><th>Cant. a bajar</th></tr></thead><tbody>';
+          posiciones.forEach(function(p){
+            var cantidad=p.cant_pos*cant;
+            html+='<tr>'+
+              `<td class="d-none"><input type="hidden" name="id_posicion[]" value="${p.id}"></td>`+
+              `<td>${p.posicion}</td>`+
+              `<td class="text-end">${p.cant_pos}</td>`+
+              `<td>${p.concepto}</td>`+
+              `<td>${p.procesos}</td>`+
+              `<td class="text-end cantidad-pos">${cantidad}<input type="hidden" name="cantidad_bajar[]" value="${cantidad}"></td>`+
+              '</tr>';
           });
-        } );
-
-        $("#link_eliminar_posiciones").on("click", function () {
-          var selectedRowsOT = dtOT.rows('.selected');
-          if (selectedRowsOT[0].length > 0) {
-            $(selectedRowsOT.nodes()).find("input[name='id_posicion[]']").each(function () {
-              tablaLC.find("#" + $(this).val()).show()
-            });
-            selectedRowsOT.remove();
-            dtOT.order([0, 'asc']).draw(false); // <— mantener orden por ID
-            refreshCantidades();
-          } else {
-            alert("Por favor seleccione una posicion para eliminar");
-          }
-        });
-    
-        $(document).on('input change',"input[name='cantidad_bajar[]']",function(){
-          var saldo = parseFloat($(this).data('saldo'));
-          var valor = parseFloat($(this).val());
-          if(valor > saldo){
-            $(this).val(saldo);
-            $(this).addClass('is-invalid');
-          }else{
-            $(this).removeClass('is-invalid');
-          }
-          console.log("entro 1");
-          refreshCantidades();
-        });
-
-        console.log("entro 2");
-        refreshCantidades();
-      });
-
-      function refreshCantidades() {
-        // ----- Actualiza LC (Cant. bajada y Saldo)
-        tablaLCDT.rows().every(function () {
-          let $row = $(this.node());
-          let cantBajadaBase     = parseFloat($row.data('cant-bajada')) || 0; // del data-* del <tr>
-          let cantTotalPosiciones = parseFloat($row.data('cant-total')) || 0;
-          let idPos = $row.attr('id');
-
-          let extra = 0;
-          let input = tablaOT.find("input[name='id_posicion[]'][value='" + idPos + "']");
-          if (input.length) {
-            let val = parseFloat(input.closest('tr').find("input[name='cantidad_bajar[]']").val());
-            if (!isNaN(val)) extra = val;
-          }
-
-          let total = cantBajadaBase + extra;
-          let saldo = cantTotalPosiciones - total;
-
-          const rIdx = this.index();
-          tablaLCDT.cell(rIdx, 8).data(total);
-          tablaLCDT.cell(rIdx, 9).data(saldo);
-          $(tablaLCDT.cell(rIdx, 8).node()).text(total);
-          $(tablaLCDT.cell(rIdx, 9).node()).text(saldo);
-        });
-
-        // ----- Actualiza OT (Saldo restante = max - valor)
-        dtOT.rows().every(function () {
-          let $tr = $(this.node());
-          let $in = $tr.find("input[name='cantidad_bajar[]']");
-          let max = parseFloat($in.data('saldo')) || 0;
-          let val = parseFloat($in.val()) || 0;
-          let restante = Math.max(0, max - val);
-
-          const rIdx = this.index();
-          dtOT.cell(rIdx, 8).data(restante);
-          $(dtOT.cell(rIdx, 8).node()).text(restante);
-        });
-      }
-
-	  
-	    function order(a, b) {
-        return b.age - a.age;
-      }
-      function selectRow(t){
-        t.addClass('selected');
-      }
-      function deselectRow(t){
-        t.removeClass('selected');
-      }
-      function updateToggleButton(){
-        var rows = tablaLCDT.rows({search:'applied'});
-        var btn = $('#toggle_seleccion');
-        var allSelected = rows.count() > 0 && tablaLCDT.rows({search:'applied', selected:true}).count() === rows.count();
-        if(allSelected){
-          btn.text('Deseleccionar todo').removeClass('btn-primary').addClass('btn-secondary');
-        }else{
-          btn.text('Seleccionar visibles').removeClass('btn-secondary').addClass('btn-primary');
+          html+='</tbody></table>';
+          return html;
         }
-      }
+
+        $('#link_agregar_posiciones').on('click',function(){
+          var selected=tablaLCDT.rows('.selected');
+          if(selected.count()===0){alert('Por favor seleccione un conjunto para agregar a la Orden de trabajo');return;}
+          selected.nodes().each(function(node){
+            var tr=$(node);
+            var nombre=tr.data('nombre');
+            var cantConj=parseInt(tr.data('cantconj'),10);
+            var saldo=parseInt(tr.data('saldo'),10);
+            var posiciones=JSON.parse(tr.data('posiciones'));
+            var input=`<input type="number" class="form-control cant-conj" value="${saldo}" data-max="${saldo}" min="0">`;
+            var rowNode=dtOT.row.add([0,nombre,cantConj,saldo,input]).draw(false).node();
+            $(rowNode).data('posiciones',posiciones);
+            dtOT.row(rowNode).child(formatPosicionesOT(posiciones,saldo)).show();
+          });
+        });
+
+        $('#link_eliminar_posiciones').on('click',function(){
+          var selected=dtOT.rows('.selected');
+          if(selected.count()===0){alert('Por favor seleccione un conjunto para eliminar');return;}
+          selected.remove().draw();
+        });
+
+        $('#tablaOT tbody').on('click','tr',function(){
+          if($(this).hasClass('selected')){
+            $(this).removeClass('selected');
+          }else{
+            dtOT.rows().nodes().to$().removeClass('selected');
+            $(this).addClass('selected');
+          }
+        });
+
+        tablaOT.on('input','.cant-conj',function(){
+          var val=parseInt($(this).val(),10);
+          var max=parseInt($(this).data('max'),10);
+          if(isNaN(val)||val<0) val=0;
+          if(val>max){val=max;$(this).val(max);}
+          var tr=$(this).closest('tr');
+          var posiciones=tr.data('posiciones');
+          dtOT.row(tr).child(formatPosicionesOT(posiciones,val)).show();
+        });
+
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- agrupa las posiciones de la lista de corte por conjunto y agrega despliegue de sus posiciones
- permite añadir conjuntos completos a la OT ajustando la cantidad de conjuntos

## Testing
- `php -l nuevaOrdenTrabajo.php`

------
https://chatgpt.com/codex/tasks/task_e_68a86af898848321a303e3b2f2f74c6d