### PR TITLE
Propagate prod parameter through dynamic listing links

### DIFF
--- a/listarComputos.php
+++ b/listarComputos.php
@@ -35,6 +35,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
 	  <link rel="stylesheet" type="text/css" href="assets/css/select2.css">
   </head>
   <body>
+    <input type="hidden" id="prod" value="<?= isset($_GET['prod']) ? (int)$_GET['prod'] : '' ?>">
     <!-- page-wrapper Start-->
     <div class="page-wrapper">
       <!-- Page Header Start--><?php
@@ -495,7 +496,8 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
     <!-- Theme js-->
     <script src="assets/js/script.js"></script>
     <script>
-      const prod = <?= isset($_GET['prod']) ? (int)$_GET['prod'] : 0 ?>;
+      const params = new URLSearchParams(window.location.search);
+      const prod = params.get('prod') || document.getElementById('prod')?.value || '';
       const prodParam = prod ? '&prod=' + prod : '';
       $(document).ready(function() {
         // Setup - add a text input to each footer cell
@@ -664,10 +666,14 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
           formRevision.append(`<input type="hidden" name="id"       value="${id}">`);
           formRevision.append(`<input type="hidden" name="modo"     value="${modo}">`);
           formRevision.append(`<input type="hidden" name="revision" value="${revision}">`);
+          if(prod){
+            formRevision.find("input[name='prod']").remove();
+            formRevision.append(`<input type="hidden" name="prod" value="${prod}">`);
+          }
           // motivo ya lo tiene como textarea name="motivoRevision"
 
           // Finalmente envío el POST al mismo script
-          formRevision.attr("action", url.pathname);
+          formRevision.attr("action", url.pathname + (prod ? '?prod=' + prod : ''));
           this.submit();
         });
 
@@ -678,7 +684,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
             alert("Por favor seleccione un cómputo para aprobar")
           } else {
             let id=$(this).data('id');
-            $("#btnAprobar").attr("href","aprobarComputo.php?id="+id);
+            $("#btnAprobar").attr("href","aprobarComputo.php?id="+id+prodParam);
           }
         })
 
@@ -688,7 +694,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
             alert("Por favor seleccione un cómputo para enviar a aprobación")
           } else {
             let id=$(this).data('id');
-            $("#btnEnviarAprobar").attr("href","aprobarComputo.php?id="+id);
+            $("#btnEnviarAprobar").attr("href","aprobarComputo.php?id="+id+prodParam);
           }
         })
 
@@ -698,7 +704,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
             alert("Por favor seleccione un cómputo no aprobado para eliminar")
           } else {
             let id=$(this).data('id');
-            $("#btnEliminar").attr("href","eliminarComputo.php?id="+id);
+            $("#btnEliminar").attr("href","eliminarComputo.php?id="+id+prodParam);
           }
         })
       
@@ -1015,7 +1021,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
           let id_computo=this.dataset.id_computo;
           let modal=$("#cancelarReservaModal");
           modal.modal("show");
-          modal.find(".btn-primary").attr("href","cancelarStockPedido.php?id="+id_computo_detalle+"&idComputo="+id_computo);
+          modal.find(".btn-primary").attr("href","cancelarStockPedido.php?id="+id_computo_detalle+"&idComputo="+id_computo+prodParam);
         });
 
       });
@@ -1094,7 +1100,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
       }
 
       function jsExportar() {
-        document.location.href="exportComputos.php?nro="+document.getElementById('nro').value+"&fecha="+document.getElementById('fecha').value+"&fechah="+document.getElementById('fechah').value+"&estado="+document.getElementById('id_estado').value;
+        document.location.href="exportComputos.php?nro="+document.getElementById('nro').value+"&fecha="+document.getElementById('fecha').value+"&fechah="+document.getElementById('fechah').value+"&estado="+document.getElementById('id_estado').value+prodParam;
       }
       
     </script>

--- a/listarListasCorte.php
+++ b/listarListasCorte.php
@@ -32,6 +32,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
 	  <link rel="stylesheet" type="text/css" href="assets/css/select2.css">
   </head>
   <body>
+    <input type="hidden" id="prod" value="<?= isset($_GET['prod']) ? (int)$_GET['prod'] : '' ?>">
     <!-- page-wrapper Start-->
     <div class="page-wrapper">
       <!-- Page Header Start--><?php
@@ -412,6 +413,9 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
     <!-- Theme js-->
     <script src="assets/js/script.js"></script>
     <script>
+      const params = new URLSearchParams(window.location.search);
+      const prod = params.get('prod') || document.getElementById('prod')?.value || '';
+      const prodParam = prod ? '&prod=' + prod : '';
       var table;
       let accionPendiente = null;
       let id_lista_corte = null;
@@ -494,7 +498,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
           }
           const filaActiva = $("#dataTables-example666 tbody tr.selected");
           const id_lista_corte = filaActiva.data("id-lista-corte");
-          formRevision.attr("action", `nuevaRevisionListaCorte.php?id_lista_corte=${id_lista_corte}`);
+          formRevision.attr("action", `nuevaRevisionListaCorte.php?id_lista_corte=${id_lista_corte}${prodParam}`);
           this.submit();
         });
 
@@ -559,11 +563,11 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
             //t.parent().find("tr").removeClass("selected");
             selectRow(t);
             get_detalle_lista_corte(id_lc)
-            $("#link_imprimir_lc").attr("target","_blank").attr("href","imprimirListaCorte.php?id="+id_lc);
+            $("#link_imprimir_lc").attr("target","_blank").attr("href","imprimirListaCorte.php?id="+id_lc+prodParam);
             if (estado != "Cancelada") {
               //$("#link_modificar_lc").attr("href","modificarListaCorte.php?id_lista_corte_revision="+id_lc);//old version
-              $("#link_modificar_lc").attr("href","nuevaListaCorte.php?modo=update&id_lista_corte="+id_lc);
-              $("#link_ot_lc").attr("href","nuevaOrdenTrabajo.php?id_lista_corte="+id_lc);
+              $("#link_modificar_lc").attr("href","nuevaListaCorte.php?modo=update&id_lista_corte="+id_lc+prodParam);
+              $("#link_ot_lc").attr("href","nuevaOrdenTrabajo.php?id_lista_corte="+id_lc+prodParam);
             } else {
               $("#link_modificar_lc").attr("href","#");
               $("#link_ot_lc").attr("href","#");
@@ -636,7 +640,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
       function cancelarLC(){
         const filaActiva = $("#dataTables-example666 tbody tr.selected");
         const id_lista_corte = filaActiva.data("id-lista-corte");
-        $("#btnEliminarListaCorte").attr("href","eliminarListaCorte.php?id="+id_lista_corte);
+        $("#btnEliminarListaCorte").attr("href","eliminarListaCorte.php?id="+id_lista_corte+prodParam);
         $("#eliminarModal").modal("show");
       }
 
@@ -658,7 +662,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
             alert('Debe seleccionar una tarea');
             return;
           }
-          window.location.href = `clonarListaCorte.php?id_lista_corte=${id}&revision=${revision}&id_tarea=${idTarea}`;
+          window.location.href = `clonarListaCorte.php?id_lista_corte=${id}&revision=${revision}&id_tarea=${idTarea}${prodParam}`;
         });
         $("#modalClonar").modal("show");
       }
@@ -765,7 +769,7 @@ $prodQuery = isset($_GET['prod']) ? '?prod='.(int)$_GET['prod'] : '';
       }
 	  
       function jsExportar() {
-        document.location.href="exportListasCorte.php?nro="+document.getElementById('nro').value+"&fecha="+document.getElementById('fecha').value+"&fechah="+document.getElementById('fechah').value+"&estado="+document.getElementById('id_estado').value;
+        document.location.href="exportListasCorte.php?nro="+document.getElementById('nro').value+"&fecha="+document.getElementById('fecha').value+"&fechah="+document.getElementById('fechah').value+"&estado="+document.getElementById('id_estado').value+prodParam;
       }
 
     </script>

--- a/listarPackingList.php
+++ b/listarPackingList.php
@@ -35,6 +35,7 @@ $prodParam = $prod ? '&prod=' . $prod : '';
 	<link rel="stylesheet" type="text/css" href="assets/css/select2.css">
   </head>
   <body>
+    <input type="hidden" id="prod" value="<?= htmlspecialchars($prod ?? '', ENT_QUOTES) ?>">
     <!-- page-wrapper Start-->
     <div class="page-wrapper">
       <!-- Page Header Start-->
@@ -511,7 +512,8 @@ $prodParam = $prod ? '&prod=' . $prod : '';
     <!-- Theme js-->
     <script src="assets/js/script.js"></script>
     <script>
-    const prod = <?= $prod ?? 0 ?>;
+    const params = new URLSearchParams(window.location.search);
+    const prod = params.get('prod') || document.getElementById('prod')?.value || '';
     const prodQuery = prod ? '?prod=' + prod : '';
     const prodParam = prod ? '&prod=' + prod : '';
     $(document).ready(function() {
@@ -1041,7 +1043,7 @@ $prodParam = $prod ? '&prod=' . $prod : '';
     }
     
 	function jsExportar() {
-		document.location.href="exportPackingList.php?nro="+document.getElementById('nro').value+"&fecha="+document.getElementById('fecha').value+"&fechah="+document.getElementById('fechah').value+"&estado="+document.getElementById('id_estado').value;
+           document.location.href="exportPackingList.php?nro="+document.getElementById('nro').value+"&fecha="+document.getElementById('fecha').value+"&fechah="+document.getElementById('fechah').value+"&estado="+document.getElementById('id_estado').value+prodParam;
 	}	
     
     </script>


### PR DESCRIPTION
## Summary
- Read `prod` from the URL or hidden field and build helper parameter strings in listing views.
- Append the `prod` query parameter to dynamic links and exports in Listas de Corte, Cómputos, and Packing List pages.

## Testing
- `php -l listarListasCorte.php`
- `php -l listarComputos.php`
- `php -l listarPackingList.php`


------
https://chatgpt.com/codex/tasks/task_e_68a86cd09830832199ec5201b7a7d43a