### PR TITLE
Set prod request flag for test scripts

### DIFF
--- a/tests/aprobarComputos copy.php
+++ b/tests/aprobarComputos copy.php
@@ -1,6 +1,7 @@
 <?php
 // tests/quicktests.php
 
+$_REQUEST['prod'] = 1;
 require '../config.php';
 require '../database.php';
 //require '../funciones.php'; // aquí está superarRevisionAnterior()

--- a/tests/aprobarComputos.php
+++ b/tests/aprobarComputos.php
@@ -1,6 +1,7 @@
 <?php
 // tests/quicktests.php
 
+$_REQUEST['prod'] = 1;
 require '../config.php';
 require '../database.php';
 //require '../funciones.php'; // aquí está superarRevisionAnterior()


### PR DESCRIPTION
## Summary
- Ensure tests set `$_REQUEST['prod']=1` before loading configuration so the desired module is enforced

## Testing
- `php tests/aprobarComputos.php` *(fails: require ../config.php: No such file or directory)*
- `php tests/aprobarComputos copy.php` *(fails: require ../config.php: No such file or directory)*
- `php tests/nuevaOrdenTrabajoInvalidQuantity.php`
- `php tests/nuevaOrdenTrabajoNoDuplicaPosiciones.php`
- `php tests/nuevaOrdenTrabajoRequiresApprovedLC.php`


------
https://chatgpt.com/codex/tasks/task_e_68a888056f3883218c319eaacc48e793