### PR TITLE
Prevent navigating away with unsaved Lista de Corte data

### DIFF
--- a/nuevaListaCorteConjuntos.php
+++ b/nuevaListaCorteConjuntos.php
@@ -437,6 +437,15 @@ Database::disconnect();?>
         $("#volverListaCorte").toggleClass("d-none")
       })
 
+      $("#volverListaCorte").on("click", function(e){
+        let nombre = $("input[name='nombre']").val();
+        let cantidad = $("input[name='cantidad']").val();
+        if(nombre !== "" || cantidad !== ""){
+          alert("No se puede guardar y volver si hay datos sin guardar.");
+          e.preventDefault();
+        }
+      });
+
       function selectRow(t){
         t.addClass('selected');
       }

--- a/nuevaListaCortePosiciones.php
+++ b/nuevaListaCortePosiciones.php
@@ -963,6 +963,21 @@ Database::disconnect();?>
 
         $(".volverConjuntos").on('click', function(e){
           e.preventDefault();
+          const nombre = $("input[name='nombre_posicion']").val();
+          const cantidad = $("input[name='cantidad_posicion']").val();
+          const material = $("select[name='id_material']").val();
+          const ancho = $("input[name='ancho']").val();
+          const largo = $("input[name='largo']").val();
+          const diametro = $("input[name='diametro']").val();
+          const marca = $("input[name='marca']").val();
+          const peso = $("input[name='peso']").val();
+          const procesos = $("input[name='proceso[]']:checked").length;
+          const terminacion = $("select[name='id_terminacion']").val();
+          const tieneDatos = nombre !== "" || cantidad !== "" || material !== "" || ancho !== "" || largo !== "" || diametro !== "" || marca !== "" || peso !== "" || procesos > 0 || terminacion !== "";
+          if(tieneDatos){
+            alert("No se puede guardar y volver si hay datos sin guardar.");
+            return;
+          }
           const url = $(this).attr('href');
           if(!conjuntoTieneMarcas()){
             if(confirm('El conjunto no tiene marcas. ¿Desea agregar?')){


### PR DESCRIPTION
## Summary
- Block "Guardar y volver" on Conjunto creation if the Nombre or Cantidad fields contain unsaved values
- Prevent leaving Posición entry when any form fields still hold data

## Testing
- `php -l nuevaListaCortePosiciones.php`
- `php -l nuevaListaCorteConjuntos.php`
- `php tests/aprobarComputos.php` (fails: Failed opening required '../config.php')
- `php tests/nuevaOrdenTrabajoInvalidQuantity.php`
- `php tests/nuevaOrdenTrabajoRequiresApprovedLC.php`
- `php tests/nuevaOrdenTrabajoNoDuplicaPosiciones.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac5b52ee2c8321a24d12198faa9859