### PR TITLE
Agregar columna de posiciones en detalle de OT

### DIFF
--- a/nuevaOrdenTrabajoPosiciones.php
+++ b/nuevaOrdenTrabajoPosiciones.php
@@ -481,6 +481,7 @@ Database::disconnect();
                                 <th>Conjunto</th>
                                 <th>Cant. conj.</th>
                                 <th>Saldo conj.</th>
+                                <th>Posiciones</th>
                                 <th>Cant. conj. a bajar</th>
                               </tr>
                             </thead>
@@ -602,7 +603,7 @@ Database::disconnect();
         });
 
         dtOT = tablaOT.DataTable({
-          columnDefs:[{targets:0,visible:false}],
+          columnDefs:[{targets:0,visible:false},{targets:4,orderable:false}],
           order:[[1,'asc']]
         });
 
@@ -636,9 +637,9 @@ Database::disconnect();
             var posiciones=tr.data('posiciones');
             console.log(posiciones);
             var input=`<input type="number" class="form-control cant-conj" value="${saldo}" data-max="${saldo}" min="0">`;
-            var rowNode=dtOT.row.add([0,nombre,cantConj,saldo,input]).draw(false).node();
+            var posHtml=formatPosicionesOT(posiciones,saldo);
+            var rowNode=dtOT.row.add([0,nombre,cantConj,saldo,posHtml,input]).draw(false).node();
             $(rowNode).data('posiciones',posiciones).data('lcrow',tr);
-            dtOT.row(rowNode).child(formatPosicionesOT(posiciones,saldo)).show();
             tr.addClass('d-none').removeClass('selected');
           });
         });
@@ -669,7 +670,8 @@ Database::disconnect();
           if(val>max){val=max;$(this).val(max);}
           var tr=$(this).closest('tr');
           var posiciones=tr.data('posiciones');
-          dtOT.row(tr).child(formatPosicionesOT(posiciones,val)).show();
+          var posHtml=formatPosicionesOT(posiciones,val);
+          dtOT.cell(tr,4).data(posHtml).draw(false);
         });
 
       });


### PR DESCRIPTION
## Resumen
- Se agregó la columna **Posiciones** al detalle de OT para reflejar las posiciones de cada conjunto.
- Se actualizó el script para renderizar la tabla de posiciones dentro de cada fila y recalcular cantidades al modificar la cantidad de conjuntos.

## Testing
- `php tests/aprobarComputos.php` (falló: falta archivo `config.php`)
- `php tests/aprobarComputos copy.php` (falló: falta archivo `config.php`)
- `php tests/nuevaOrdenTrabajoInvalidQuantity.php`
- `php tests/nuevaOrdenTrabajoRequiresApprovedLC.php`
- `php tests/nuevaOrdenTrabajoNoDuplicaPosiciones.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac627b96608321963bd356626d97ac