### PR TITLE
Add date handling and validation for OT quantity updates

### DIFF
--- a/listarOrdenesTrabajo.php
+++ b/listarOrdenesTrabajo.php
@@ -286,6 +286,9 @@ include 'database.php';
             <div class="modal-body">
               <div class="form-group row">
                 <input type="hidden" name="id_posicion_ot" id="id_posicion_ot">
+                <input type="hidden" id="liberadas_actual" value="0">
+                <input type="hidden" id="rechazadas_actual" value="0">
+                <input type="hidden" id="reproceso_actual" value="0">
                 <label class="col-sm-3 col-form-label">Reproceso</label>
                 <div class="col-sm-9"><input name="enProceso" type="number" class="form-control"></div>
               </div>
@@ -297,7 +300,11 @@ include 'database.php';
                 <label class="col-sm-3 col-form-label">Liberados</label>
                 <div class="col-sm-9"><input name="liberadas" type="number" class="form-control"></div>
               </div>
-			        <div class="form-group row">
+              <div class="form-group row">
+                <label class="col-sm-3 col-form-label">Fecha</label>
+                <div class="col-sm-9"><input name="fecha" type="datetime-local" class="form-control"></div>
+              </div>
+              <div class="form-group row">
                 <label class="col-sm-3 col-form-label">Motivo</label>
                 <div class="col-sm-9"><input name="motivo" type="text" class="form-control"></div>
               </div>
@@ -502,29 +509,50 @@ include 'database.php';
             alert("Por favor seleccione una posicion para modificar las cantidades")
           }
         });
+
+        $("#modificarCantidades").on('shown.bs.modal',function(){
+          let now=new Date();
+          let local=new Date(now.getTime() - now.getTimezoneOffset()*60000).toISOString().slice(0,16);
+          $(this).find("input[name='fecha']").val(local);
+          $(this).find("input[name='enProceso'],input[name='rechazadas'],input[name='liberadas'],input[name='motivo']").val("");
+          $(this).find("input[name='motivo']").prop('required',false);
+        });
+
+        $("input[name='rechazadas']").on('input',function(){
+          let motivo=$("input[name='motivo']");
+          if(parseInt($(this).val())>0){
+            motivo.prop('required',true);
+          }else{
+            motivo.prop('required',false);
+          }
+        });
 		
-		    $("#btnDetalle").on("click",function(e){
+        $("#btnDetalle").on("click",function(e){
           let id_conjunto=$(this).data("id")
           if(id_conjunto!="" && id_conjunto>0){
-			      window.location.href="verHistorialOT.php?id="+id_conjunto
+                              window.location.href="verHistorialOT.php?id="+id_conjunto
           }else{
             alert("Por favor seleccione una posicion para ver el historial")
           }
         });
 		
 		
-		    $("#btnModificarCantidades").on("click",function(e){
+        $("#btnModificarCantidades").on("click",function(e){
           e.preventDefault();
           let form=$("#formModificarCantidades");
-          let enProceso=parseInt(form.find("input[name='enProceso']").val());
-          let rechazadas=parseInt(form.find("input[name='rechazadas']").val());
-          let liberadas=parseInt(form.find("input[name='liberadas']").val());
-          let cantMaxima=parseInt($("#cantMaxima").html());
+          let enProceso=parseInt(form.find("input[name='enProceso']").val())||0;
+          let rechazadas=parseInt(form.find("input[name='rechazadas']").val())||0;
+          let liberadas=parseInt(form.find("input[name='liberadas']").val())||0;
+          let cantMaxima=parseInt($("#cantMaxima").html())||0;
+          let libAct=parseInt($("#liberadas_actual").val())||0;
+          let rechAct=parseInt($("#rechazadas_actual").val())||0;
+          let motivo=form.find("input[name='motivo']").val();
 
-          if((enProceso+rechazadas+liberadas)>cantMaxima){
-            alert("La suma de los 3 campos no puede superar la cantida maxima ("+cantMaxima+")")
+          if(rechazadas>0 && motivo.trim()==""){
+            alert("Debe ingresar el motivo del rechazo");
+          }else if((liberadas+libAct+rechazadas+rechAct)>cantMaxima){
+            alert("La suma de liberadas y rechazadas no puede superar la cantidad pedida ("+cantMaxima+")");
           }else{
-            console.log("submit");
             form.submit();
           }
         });
@@ -627,21 +655,30 @@ include 'database.php';
 
               let id_pos_ot=t.find("td:first-child").html();
               let cantMaxima=t.find("td:nth-child(5)").html();
+              let cantLibAct=t.find("td:nth-child(9)").html();
+              let cantRepAct=t.find("td:nth-child(10)").html();
+              let cantRechAct=t.find("td:nth-child(11)").html();
               if(t.hasClass('selected')){
                 deselectRow(t);
                 $("#btnAbrirModalModificarCantidades").data("id","");
-				        $("#btnDetalle").data("id","");
-                $("#cantMaxima").html("")
-                $("#id_posicion_ot").val("")
+                $("#btnDetalle").data("id","");
+                $("#cantMaxima").html("");
+                $("#id_posicion_ot").val("");
+                $("#liberadas_actual").val(0);
+                $("#rechazadas_actual").val(0);
+                $("#reproceso_actual").val(0);
               }else{
                 table.rows().nodes().each( function (rowNode, index) {
                   $(rowNode).removeClass("selected");
                 });
                 selectRow(t);
                 $("#btnAbrirModalModificarCantidades").data("id",id_pos_ot);
-				        $("#btnDetalle").data("id",id_pos_ot);
-                $("#cantMaxima").html(cantMaxima)
-                $("#id_posicion_ot").val(id_pos_ot)
+                $("#btnDetalle").data("id",id_pos_ot);
+                $("#cantMaxima").html(cantMaxima);
+                $("#id_posicion_ot").val(id_pos_ot);
+                $("#liberadas_actual").val(cantLibAct);
+                $("#rechazadas_actual").val(cantRechAct);
+                $("#reproceso_actual").val(cantRepAct);
               }
             });
           }

--- a/modificarCantidadesPosicionesOT.php
+++ b/modificarCantidadesPosicionesOT.php
@@ -7,45 +7,55 @@ if (empty($_SESSION['user'])) {
 
 require 'database.php';
 
-$id = null;
-if (!empty($_GET['id'])) {
-  $id = $_REQUEST['id'];
-}
-
-if (null==$id) {
-  header("Location: listarOrdenesTrabajo.php");
-}
-
 $pdo = Database::connect();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
-$sql = "UPDATE ordenes_trabajo_detalle SET cant_liberadas = ?, cant_proceso = ?, cant_rechazadas = ?, fecha = now(), id_usuario = ? WHERE id = ?";
-$q = $pdo->prepare($sql);
-$q->execute([$_POST["liberadas"],$_POST["enProceso"],$_POST["rechazadas"],$_SESSION['user']['id'],$_POST["id_posicion_ot"]]);
+$idDetalle = $_POST["id_posicion_ot"];
+$fecha = isset($_POST['fecha']) ? date('Y-m-d H:i:s', strtotime($_POST['fecha'])) : date('Y-m-d H:i:s');
 
-$sql = "INSERT INTO `ordenes_trabajo_detalle_log`(`id_ordenes_trabajo_detalle`, `cantidad_liberada`, `cantidad_reproceso`, `cantidad_rechazada`, `motivo`, `fecha`, `id_usuario`) VALUES (?,?,?,?,?,now(),?)";
+// Obtener totales actuales de la posición
+$sql = "SELECT cantidad, cant_liberadas, cant_proceso, cant_rechazadas, id_orden_trabajo FROM ordenes_trabajo_detalle WHERE id = ?";
 $q = $pdo->prepare($sql);
-$q->execute([$_POST["id_posicion_ot"],$_POST["liberadas"],$_POST["enProceso"],$_POST["rechazadas"],$_POST["motivo"],$_SESSION['user']['id']]);
+$q->execute([$idDetalle]);
+$data = $q->fetch(PDO::FETCH_ASSOC);
 
+$n_liberadas  = $data['cant_liberadas'] + $_POST['liberadas'];
+$n_proceso    = $data['cant_proceso'] + $_POST['enProceso'];
+$n_rechazadas = $data['cant_rechazadas'] + $_POST['rechazadas'];
+
+if(($n_liberadas + $n_rechazadas) > $data['cantidad']){
+  Database::disconnect();
+  header("Location: listarOrdenesTrabajo.php");
+  exit;
+}
+
+// Actualizar totales
+$sql = "UPDATE ordenes_trabajo_detalle SET cant_liberadas = ?, cant_proceso = ?, cant_rechazadas = ?, fecha = ?, id_usuario = ? WHERE id = ?";
+$q = $pdo->prepare($sql);
+$q->execute([$n_liberadas, $n_proceso, $n_rechazadas, $fecha, $_SESSION['user']['id'], $idDetalle]);
+
+// Registrar movimiento en el log
+$sql = "INSERT INTO ordenes_trabajo_detalle_log(id_ordenes_trabajo_detalle, cantidad_liberada, cantidad_reproceso, cantidad_rechazada, motivo, fecha, id_usuario) VALUES (?,?,?,?,?,?,?)";
+$q = $pdo->prepare($sql);
+$q->execute([$idDetalle, $_POST["liberadas"], $_POST["enProceso"], $_POST["rechazadas"], $_POST["motivo"], $fecha, $_SESSION['user']['id']]);
+
+// Auditoría general
 $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo) VALUES (now(),?,'Modificacion de Cantidades en Orden de Trabajo','Orden de Trabajo')";
 $q = $pdo->prepare($sql);
-$q->execute(array($_SESSION['user']['id']));
+$q->execute([$_SESSION['user']['id']]);
 
-$sql = "SELECT id_orden_trabajo from ordenes_trabajo_detalle where id = ?";
-$q = $pdo->prepare($sql);
-$q->execute([$_POST["id_posicion_ot"]]);
-$data = $q->fetch(PDO::FETCH_ASSOC);
 $idOT = $data['id_orden_trabajo'];
 
-$sql = "SELECT sum(d.cantidad) total, sum(d.cant_liberadas) lib from ordenes_trabajo_detalle d where d.id_orden_trabajo = ?";
+$sql = "SELECT sum(d.cantidad) total, sum(d.cant_liberadas) lib, sum(d.cant_rechazadas) rech FROM ordenes_trabajo_detalle d where d.id_orden_trabajo = ?";
 $q = $pdo->prepare($sql);
 $q->execute([$idOT]);
 $data = $q->fetch(PDO::FETCH_ASSOC);
-if ($data['lib'] >= $data['total']) {
-	$sql = "update ordenes_trabajo set id_estado_orden_trabajo = 4 where id = ?";
-	$q = $pdo->prepare($sql);
-	$q->execute([$idOT]);	
+if (($data['lib'] + $data['rech']) >= $data['total']) {
+  $sql = "update ordenes_trabajo set id_estado_orden_trabajo = 4 where id = ?";
+  $q = $pdo->prepare($sql);
+  $q->execute([$idOT]);
 }
 
 Database::disconnect();
 header("Location: listarOrdenesTrabajo.php");
+


### PR DESCRIPTION
## Summary
- allow entering custom date/time when updating OT quantities
- require rejection reason and validate liberated + rejected totals
- accumulate quantities and log each update with provided timestamp

## Testing
- `php -l listarOrdenesTrabajo.php`
- `php -l modificarCantidadesPosicionesOT.php`


------
https://chatgpt.com/codex/tasks/task_e_68ada8635f64832183a86c2df4fb9cb8