### PR TITLE
Include OT id when updating position quantities

### DIFF
--- a/listarOrdenesTrabajo.php
+++ b/listarOrdenesTrabajo.php
@@ -286,6 +286,7 @@ include 'database.php';
             <div class="modal-body">
               <div class="form-group row">
                 <input type="hidden" name="id_posicion_ot" id="id_posicion_ot">
+                <input type="hidden" name="id_orden_trabajo" id="id_orden_trabajo">
                 <input type="hidden" id="liberadas_actual" value="0">
                 <input type="hidden" id="rechazadas_actual" value="0">
                 <input type="hidden" id="reproceso_actual" value="0">
@@ -425,6 +426,7 @@ include 'database.php';
             $("#link_nuevo_consumo").attr("href","#");
             $("#link_cancelar_ot").attr("data-target","#");
             $("#btnEliminarOT").attr("href","#");
+            $("#id_orden_trabajo").val('');
           }else{
             //t.parent().find("tr").removeClass("selected");
             table.rows().nodes().each( function (rowNode, index) {
@@ -432,6 +434,7 @@ include 'database.php';
             });
             selectRow(t);
             get_detalle_orden_trabajo(id_ot)
+            $("#id_orden_trabajo").val(id_ot);
             if ((estado == "Elaborando") || (estado == "Para Aprobar")) {
               $("#link_modificar_ot").attr("href","nuevaOrdenTrabajo.php?id="+id_ot);
             } else {

--- a/modificarCantidadesPosicionesOT.php
+++ b/modificarCantidadesPosicionesOT.php
@@ -11,12 +11,13 @@ $pdo = Database::connect();
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $idDetalle = $_POST["id_posicion_ot"];
+$idOT = $_POST["id_orden_trabajo"];
 $fecha = isset($_POST['fecha']) ? date('Y-m-d H:i:s', strtotime($_POST['fecha'])) : date('Y-m-d H:i:s');
 
 // Obtener totales actuales de la posición
-$sql = "SELECT cantidad, cant_liberadas, cant_proceso, cant_rechazadas, id_orden_trabajo FROM ordenes_trabajo_detalle WHERE id = ?";
+$sql = "SELECT cantidad, cant_liberadas, cant_proceso, cant_rechazadas FROM ordenes_trabajo_detalle WHERE id = ? AND id_orden_trabajo = ?";
 $q = $pdo->prepare($sql);
-$q->execute([$idDetalle]);
+$q->execute([$idDetalle, $idOT]);
 $data = $q->fetch(PDO::FETCH_ASSOC);
 
 $n_liberadas  = $data['cant_liberadas'] + $_POST['liberadas'];
@@ -43,8 +44,6 @@ $q->execute([$idDetalle, $_POST["liberadas"], $_POST["enProceso"], $_POST["recha
 $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo) VALUES (now(),?,'Modificacion de Cantidades en Orden de Trabajo','Orden de Trabajo')";
 $q = $pdo->prepare($sql);
 $q->execute([$_SESSION['user']['id']]);
-
-$idOT = $data['id_orden_trabajo'];
 
 $sql = "SELECT sum(d.cantidad) total, sum(d.cant_liberadas) lib, sum(d.cant_rechazadas) rech FROM ordenes_trabajo_detalle d where d.id_orden_trabajo = ?";
 $q = $pdo->prepare($sql);


### PR DESCRIPTION
## Summary
- Add hidden OT ID field to position quantity update form
- Ensure selected OT ID is sent when editing quantities
- Accept OT ID in quantity update endpoint and validate against it

## Testing
- `php -l listarOrdenesTrabajo.php`
- `php -l modificarCantidadesPosicionesOT.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae07e3221c83219838c984afdb8109