### PR TITLE
Sync OT and position states during workflow

### DIFF
--- a/enviarProduccionOT.php
+++ b/enviarProduccionOT.php
@@ -18,6 +18,11 @@ if ($id) {
   $q->execute([$id]);
 
   if ($q->rowCount() > 0) {
+    // Actualizar estado de las posiciones
+    $sqlDet = "UPDATE ordenes_trabajo_detalle SET id_estado_orden_trabajo_posicion = 3 WHERE id_orden_trabajo = ?";
+    $qDet = $pdo->prepare($sqlDet);
+    $qDet->execute([$id]);
+
     // Registrar log
     $sqlLog = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion, modulo, link) VALUES (now(), ?, 'Envio a producción OT', 'Orden de Trabajo', 'verOrdenTrabajo.php?id=$id')";
     $qLog = $pdo->prepare($sqlLog);

--- a/modificarCantidadesPosicionesOT.php
+++ b/modificarCantidadesPosicionesOT.php
@@ -53,6 +53,13 @@ $sql = "UPDATE ordenes_trabajo_detalle SET cant_liberadas = ?, cant_proceso = ?,
 $q = $pdo->prepare($sql);
 $q->execute([$n_liberadas, $n_proceso, $n_rechazadas, $fecha, $_SESSION['user']['id'], $idDetalle]);
 
+// Si la suma de liberadas y rechazadas completa la cantidad, marcar la posición como Terminada
+if(($n_liberadas + $n_rechazadas) == $data['cantidad']){
+  $sql = "UPDATE ordenes_trabajo_detalle SET id_estado_orden_trabajo_posicion = 4 WHERE id = ?";
+  $q = $pdo->prepare($sql);
+  $q->execute([$idDetalle]);
+}
+
 // Registrar movimiento en el log
 $sql = "INSERT INTO ordenes_trabajo_detalle_log(id_ordenes_trabajo_detalle, cantidad_liberada, cantidad_reproceso, cantidad_rechazada, motivo, fecha, id_usuario) VALUES (?,?,?,?,?,?,?)";
 $q = $pdo->prepare($sql);
@@ -63,12 +70,13 @@ $sql = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo) VALUES (
 $q = $pdo->prepare($sql);
 $q->execute([$_SESSION['user']['id']]);
 
-$sql = "SELECT sum(d.cantidad) total, sum(d.cant_liberadas) lib, sum(d.cant_rechazadas) rech FROM ordenes_trabajo_detalle d where d.id_orden_trabajo = ?";
+// Si todas las posiciones de la OT están terminadas, actualizar estado de la OT
+$sql = "SELECT COUNT(*) total, SUM(CASE WHEN id_estado_orden_trabajo_posicion = 4 THEN 1 ELSE 0 END) terminadas FROM ordenes_trabajo_detalle WHERE id_orden_trabajo = ?";
 $q = $pdo->prepare($sql);
 $q->execute([$id_orden_trabajo]);
 $data = $q->fetch(PDO::FETCH_ASSOC);
-if (($data['lib'] + $data['rech']) >= $data['total']) {
-  $sql = "update ordenes_trabajo set id_estado_orden_trabajo = 4 where id = ?";
+if ($data['total'] > 0 && $data['total'] == $data['terminadas']) {
+  $sql = "UPDATE ordenes_trabajo SET id_estado_orden_trabajo = 4 WHERE id = ?";
   $q = $pdo->prepare($sql);
   $q->execute([$id_orden_trabajo]);
 }

--- a/modificarEstadoOT.php
+++ b/modificarEstadoOT.php
@@ -12,7 +12,15 @@ $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 
 $sql = "UPDATE ordenes_trabajo SET id_estado_orden_trabajo = ? WHERE id = ?";
 $q = $pdo->prepare($sql);
-$q->execute([$_POST["idEstado"],$_POST["idPosicion"]]);
+$q->execute([$_POST["idEstado"], $_POST["idPosicion"]]);
+
+// Si la OT pasa a "Para aprobar" (2) o "En producción" (3),
+// actualizamos también el estado de todas sus posiciones
+if (in_array((int)$_POST["idEstado"], [2, 3])) {
+    $sql = "UPDATE ordenes_trabajo_detalle SET id_estado_orden_trabajo_posicion = ? WHERE id_orden_trabajo = ?";
+    $q = $pdo->prepare($sql);
+    $q->execute([$_POST["idEstado"], $_POST["idPosicion"]]);
+}
 
 Database::disconnect();
 

--- a/nuevaOrdenTrabajo.php
+++ b/nuevaOrdenTrabajo.php
@@ -197,6 +197,11 @@ if (!empty($_POST)) {
       $q = $pdo->prepare($sql);
       $q->execute([$id_orden_trabajo]);
 
+      // Actualizar estado de todas las posiciones
+      $sql = "UPDATE ordenes_trabajo_detalle SET id_estado_orden_trabajo_posicion = 2 WHERE id_orden_trabajo = ?";
+      $q = $pdo->prepare($sql);
+      $q->execute([$id_orden_trabajo]);
+
       $sql = "SELECT l.numero AS numero_lc, l.id_proyecto, ot.nro_orden_trabajo FROM ordenes_trabajo ot JOIN listas_corte l ON l.id = ot.id_lista_corte WHERE ot.id = ?";
       $q = $pdo->prepare($sql);
       $q->execute([$id_orden_trabajo]);

--- a/nuevaOrdenTrabajoFilaPorPosicion.php
+++ b/nuevaOrdenTrabajoFilaPorPosicion.php
@@ -147,6 +147,11 @@ if (!empty($_POST)) {
       $q = $pdo->prepare($sql);
       $q->execute([$id_orden_trabajo]);
 
+      // Actualizar estado de todas las posiciones
+      $sql = "UPDATE ordenes_trabajo_detalle SET id_estado_orden_trabajo_posicion = 2 WHERE id_orden_trabajo = ?";
+      $q = $pdo->prepare($sql);
+      $q->execute([$id_orden_trabajo]);
+
       $sql = "SELECT l.numero AS numero_lc, l.id_proyecto, ot.nro_orden_trabajo FROM ordenes_trabajo ot JOIN listas_corte l ON l.id = ot.id_lista_corte WHERE ot.id = ?";
       $q = $pdo->prepare($sql);
       $q->execute([$id_orden_trabajo]);

--- a/nuevaOrdenTrabajoPosicionesDesplegables.php
+++ b/nuevaOrdenTrabajoPosicionesDesplegables.php
@@ -187,6 +187,11 @@ if (!empty($_POST)) {
       $q = $pdo->prepare($sql);
       $q->execute([$id_orden_trabajo]);
 
+      // Actualizar estado de todas las posiciones
+      $sql = "UPDATE ordenes_trabajo_detalle SET id_estado_orden_trabajo_posicion = 2 WHERE id_orden_trabajo = ?";
+      $q = $pdo->prepare($sql);
+      $q->execute([$id_orden_trabajo]);
+
       $sql = "SELECT l.numero AS numero_lc, l.id_proyecto, ot.nro_orden_trabajo FROM ordenes_trabajo ot JOIN listas_corte l ON l.id = ot.id_lista_corte WHERE ot.id = ?";
       $q = $pdo->prepare($sql);
       $q->execute([$id_orden_trabajo]);


### PR DESCRIPTION
## Summary
- Propagate state changes to all OT positions when moving to approval or production
- Mark positions and entire OTs as finished when released and rejected quantities match requests

## Testing
- `php -l modificarEstadoOT.php`
- `php -l enviarProduccionOT.php`
- `php -l nuevaOrdenTrabajo.php`
- `php -l nuevaOrdenTrabajoPosicionesDesplegables.php`
- `php -l nuevaOrdenTrabajoFilaPorPosicion.php`
- `php -l modificarCantidadesPosicionesOT.php`
- `php aprobarComputos.php`
- `php "aprobarComputos copy.php"`
- `php nuevaOrdenTrabajoInvalidQuantity.php`
- `php nuevaOrdenTrabajoNoDuplicaPosiciones.php`
- `php nuevaOrdenTrabajoRequiresApprovedLC.php`


------
https://chatgpt.com/codex/tasks/task_e_68aee818a8708321a3e73165eea55d39