### PR TITLE
Restrict OT quantity edits outside production

### DIFF
--- a/listarOrdenesTrabajo.php
+++ b/listarOrdenesTrabajo.php
@@ -360,6 +360,9 @@ include 'database.php';
     <script>
       $(document).ready(function() {
 
+        let estadoOT = '';
+        $("#btnAbrirModalModificarCantidades").hide();
+
         // Setup - add a text input to each footer cell
         $('#tablaOT tfoot th').each( function () {
           var title = $(this).text();
@@ -415,7 +418,7 @@ include 'database.php';
           var t=$(this).parent();
 
           let id_ot=t.find("td:first-child").html();
-                      let estado = t.find("td:nth-child(10)").html();
+          let estado = t.find("td:nth-child(10)").html();
           if(t.hasClass('selected')){
             deselectRow(t);
             get_detalle_orden_trabajo(0)
@@ -427,6 +430,8 @@ include 'database.php';
             $("#link_cancelar_ot").attr("data-target","#");
             $("#btnEliminarOT").attr("href","#");
             $("#id_orden_trabajo").val('');
+            estadoOT='';
+            $("#btnAbrirModalModificarCantidades").hide();
           }else{
             //t.parent().find("tr").removeClass("selected");
             table.rows().nodes().each( function (rowNode, index) {
@@ -435,7 +440,8 @@ include 'database.php';
             selectRow(t);
             get_detalle_orden_trabajo(id_ot)
             $("#id_orden_trabajo").val(id_ot);
-            if ((estado == "Elaboracion") || (estado == "Para Aprobar")) {
+            estadoOT = estado;
+            if (estado == "Elaboracion" || estado == "Para Aprobar") {
               $("#link_modificar_ot").attr("href","nuevaOrdenTrabajo.php?id="+id_ot);
             } else {
               $("#link_modificar_ot").attr("href","#");
@@ -447,8 +453,10 @@ include 'database.php';
             }
             if (estado == "En Produccion") {
               $("#link_nuevo_consumo").attr("href","nuevoConsumo.php?id_orden_trabajo="+id_ot);
+              $("#btnAbrirModalModificarCantidades").show();
             } else {
               $("#link_nuevo_consumo").attr("href","#");
+              $("#btnAbrirModalModificarCantidades").hide();
             }
 
             $("#link_ver_ot").attr("href","verOrdenTrabajo.php?id="+id_ot);
@@ -504,7 +512,10 @@ include 'database.php';
 
         $("#btnAbrirModalModificarCantidades").on("click",function(){
           let id_posicion=$(this).data("id")
-          console.log(id_posicion);
+          if(estadoOT!="En Produccion"){
+            alert("Solo se pueden modificar cantidades con la OT en estado 'En Produccion'");
+            return;
+          }
           if(id_posicion!="" && id_posicion>0){
             let modal=$("#modificarCantidades")
             modal.modal("show")

--- a/modificarCantidadesPosicionesOT.php
+++ b/modificarCantidadesPosicionesOT.php
@@ -25,6 +25,17 @@ $liberadas = $_POST['liberadas'] ?: 0;
 $reproceso = $_POST['reproceso'] ?: 0;
 $rechazadas = $_POST['rechazadas'] ?: 0;
 
+$sql = "SELECT id_estado_orden_trabajo FROM ordenes_trabajo WHERE id = ?";
+$q = $pdo->prepare($sql);
+$q->execute([$id_orden_trabajo]);
+$estadoOT = $q->fetchColumn();
+if($estadoOT != 3){
+  $pdo->rollBack();
+  Database::disconnect();
+  header("Location: listarOrdenesTrabajo.php");
+  exit;
+}
+
 // Obtener totales actuales de la posición
 $sql = "SELECT id, cantidad, cant_liberadas, cant_reproceso, cant_rechazadas FROM ordenes_trabajo_detalle WHERE id_posicion = ? AND id_orden_trabajo = ?";
 $q = $pdo->prepare($sql);


### PR DESCRIPTION
## Summary
- Hide quantity modification option unless the selected OT is in 'En Produccion'
- Validate OT state on the server before applying quantity changes

## Testing
- `php -l listarOrdenesTrabajo.php`
- `php -l modificarCantidadesPosicionesOT.php`


------
https://chatgpt.com/codex/tasks/task_e_68aeedcb910c8321bc4ca4ea31639907