### PR TITLE
Actualizar estado de pedido tras generar compra

### DIFF
--- a/gestionarPedido.php
+++ b/gestionarPedido.php
@@ -118,6 +118,10 @@ if (!empty($_POST)) {
         }
       }
 
+      $sqlEstadoPedido = "UPDATE pedidos SET id_estado = 4 WHERE id = ?";
+      $qEstadoPedido = $pdo->prepare($sqlEstadoPedido);
+      $qEstadoPedido->execute([$id]);
+
       $sql_log = "INSERT INTO logs(fecha_hora, id_usuario, detalle_accion,modulo,link) VALUES (now(),?,'Nueva orden de compra','Compras','verCompra.php?id=$idCompra')";
       $q_log = $pdo->prepare($sql_log);
       $q_log->execute([$_SESSION['user']['id']]);


### PR DESCRIPTION
## Summary
- add update to mark pedidos as estado 4 after creating a purchase and its details
- keep existing workflow and redirects intact

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f98ea7030832190cb092ccf1d1f34)